### PR TITLE
feat: staticEntities

### DIFF
--- a/src/main/scala/io/github/srs/model/StaticEntity.scala
+++ b/src/main/scala/io/github/srs/model/StaticEntity.scala
@@ -24,6 +24,7 @@ enum StaticEntity(val position: Point2D, val orientation: Orientation) extends E
     case Obstacle(_, _, w, h) => ShapeType.Rectangle(w, h)
     case Light(_, _, r, _, _) => ShapeType.Circle(r)
 
+end StaticEntity
 
 object StaticEntity:
 
@@ -49,4 +50,4 @@ object StaticEntity:
       i <- positive("intensity", intensity)
       a <- positive("attenuation", attenuation)
     yield StaticEntity.Light(pos, orient, radius, i, a)
-
+end StaticEntity

--- a/src/main/scala/io/github/srs/model/StaticEntity.scala
+++ b/src/main/scala/io/github/srs/model/StaticEntity.scala
@@ -3,8 +3,25 @@ package io.github.srs.model
 import io.github.srs.model.validation.Validation
 import io.github.srs.model.validation.Validation.*
 
+/**
+ * Represents a static entity in a two-dimensional space.
+ *
+ * A static entity is characterized by its position, orientation, and shape.
+ */
 enum StaticEntity(val position: Point2D, val orientation: Orientation) extends Entity:
 
+  /**
+   * The [[Obstacle]] represents a rectangular obstacle in the simulation environment.
+   *
+   * @param pos
+   *   center position of the obstacle
+   * @param orient
+   *   orientation of the obstacle
+   * @param width
+   *   width of the obstacle
+   * @param height
+   *   height of the obstacle
+   */
   case Obstacle(
       pos: Point2D,
       orient: Orientation,
@@ -12,6 +29,20 @@ enum StaticEntity(val position: Point2D, val orientation: Orientation) extends E
       height: Double,
   ) extends StaticEntity(pos, orient)
 
+  /**
+   * The [[Light]] represents a light source in the simulation environment.
+   *
+   * @param pos
+   *   center position of the light
+   * @param orient
+   *   orientation of the light
+   * @param radius
+   *   radius of the light's influence
+   * @param intensity
+   *   intensity of the light
+   * @param attenuation
+   *   attenuation factor of the light
+   */
   case Light(
       pos: Point2D,
       orient: Orientation,
@@ -20,14 +51,37 @@ enum StaticEntity(val position: Point2D, val orientation: Orientation) extends E
       attenuation: Double,
   ) extends StaticEntity(pos, orient)
 
+  /**
+   * The shape type of the static entity.
+   *
+   * @return
+   *   the [[ShapeType]] that defines the geometric shape of this static entity.
+   */
   override def shape: ShapeType = this match
     case Obstacle(_, _, w, h) => ShapeType.Rectangle(w, h)
     case Light(_, _, r, _, _) => ShapeType.Circle(r)
 
 end StaticEntity
 
+/**
+ * Companion object for [[StaticEntity]], providing factory methods for creating instances.
+ */
 object StaticEntity:
 
+  /**
+   * Safely build an [[Obstacle]], reflecting the domain constraints.
+   *
+   * @param pos
+   *   center position of the obstacle
+   * @param orient
+   *   orientation of the obstacle
+   * @param width
+   *   width of the obstacle
+   * @param height
+   *   height of the obstacle
+   * @return
+   *   [[Right]] with the created [[StaticEntity.Obstacle]] if valid, otherwise [[Left]] with a validation error.
+   */
   def obstacle(
       pos: Point2D,
       orient: Orientation,
@@ -39,6 +93,21 @@ object StaticEntity:
       h <- positive("height", height)
     yield StaticEntity.Obstacle(pos, orient, w, h)
 
+  /**
+   * Safely build a [[Light]], reflecting the domain constraints.
+   * @param pos
+   *   center position of the light
+   * @param orient
+   *   orientation of the light
+   * @param radius
+   *   radius of the light's influence
+   * @param intensity
+   *   intensity of the light
+   * @param attenuation
+   *   attenuation factor of the light
+   * @return
+   *   [[Right]] with the created [[StaticEntity.Light]] if valid, otherwise [[Left]] with a validation error.
+   */
   def light(
       pos: Point2D,
       orient: Orientation,

--- a/src/main/scala/io/github/srs/model/StaticEntity.scala
+++ b/src/main/scala/io/github/srs/model/StaticEntity.scala
@@ -116,7 +116,8 @@ object StaticEntity:
       attenuation: Double,
   ): Validation[StaticEntity] =
     for
+      r <- positive("radius", radius)
       i <- positive("intensity", intensity)
       a <- positive("attenuation", attenuation)
-    yield StaticEntity.Light(pos, orient, radius, i, a)
+    yield StaticEntity.Light(pos, orient, r, i, a)
 end StaticEntity

--- a/src/main/scala/io/github/srs/model/StaticEntity.scala
+++ b/src/main/scala/io/github/srs/model/StaticEntity.scala
@@ -1,0 +1,52 @@
+package io.github.srs.model
+
+import io.github.srs.model.validation.Validation
+import io.github.srs.model.validation.Validation.*
+
+enum StaticEntity(val position: Point2D, val orientation: Orientation) extends Entity:
+
+  case Obstacle(
+      pos: Point2D,
+      orient: Orientation,
+      width: Double,
+      height: Double,
+  ) extends StaticEntity(pos, orient)
+
+  case Light(
+      pos: Point2D,
+      orient: Orientation,
+      radius: Double,
+      intensity: Double,
+      attenuation: Double,
+  ) extends StaticEntity(pos, orient)
+
+  override def shape: ShapeType = this match
+    case Obstacle(_, _, w, h) => ShapeType.Rectangle(w, h)
+    case Light(_, _, r, _, _) => ShapeType.Circle(r)
+
+
+object StaticEntity:
+
+  def obstacle(
+      pos: Point2D,
+      orient: Orientation,
+      width: Int,
+      height: Int,
+  ): Validation[StaticEntity] =
+    for
+      w <- positive("width", width)
+      h <- positive("height", height)
+    yield StaticEntity.Obstacle(pos, orient, w, h)
+
+  def light(
+      pos: Point2D,
+      orient: Orientation,
+      radius: Double,
+      intensity: Double,
+      attenuation: Double,
+  ): Validation[StaticEntity] =
+    for
+      i <- positive("intensity", intensity)
+      a <- positive("attenuation", attenuation)
+    yield StaticEntity.Light(pos, orient, radius, i, a)
+

--- a/src/main/scala/io/github/srs/model/validation/Validation.scala
+++ b/src/main/scala/io/github/srs/model/validation/Validation.scala
@@ -7,9 +7,10 @@ type Validation[+A] = Either[DomainError, A]
 
 object Validation:
   import scala.math.Numeric
+
   def positive[T](field: String, v: T)(using n: Numeric[T]): Validation[T] =
     Either.cond(
       n.gt(v, n.zero),
       v,
-      DomainError.NegativeOrZero(field, n.toDouble(v))
+      DomainError.NegativeOrZero(field, n.toDouble(v)),
     )

--- a/src/main/scala/io/github/srs/model/validation/Validation.scala
+++ b/src/main/scala/io/github/srs/model/validation/Validation.scala
@@ -1,0 +1,15 @@
+package io.github.srs.model.validation
+
+enum DomainError:
+  case NegativeOrZero(field: String, value: Double)
+
+type Validation[+A] = Either[DomainError, A]
+
+object Validation:
+  import scala.math.Numeric
+  def positive[T](field: String, v: T)(using n: Numeric[T]): Validation[T] =
+    Either.cond(
+      n.gt(v, n.zero),
+      v,
+      DomainError.NegativeOrZero(field, n.toDouble(v))
+    )

--- a/src/main/scala/io/github/srs/model/validation/Validation.scala
+++ b/src/main/scala/io/github/srs/model/validation/Validation.scala
@@ -1,16 +1,46 @@
 package io.github.srs.model.validation
 
+/**
+ * ADT collecting validation failures that are meaningful in the domain.
+ */
 enum DomainError:
   case NegativeOrZero(field: String, value: Double)
 
+/**
+ * Type alias for domain‑level validations: `Right` = valid, `Left` = error.
+ */
 type Validation[+A] = Either[DomainError, A]
 
+/**
+ * Companion object for [[Validation]] that provides utility methods for common validations.
+ */
 object Validation:
   import scala.math.Numeric
 
+  /**
+   * Ensures the given numeric value is strictly positive.
+   *
+   * @param field
+   *   name of the validated field (for error reporting)
+   * @param v
+   *   numeric value to check
+   * @tparam T
+   *   any [[Numeric]] type (e.g., `Int`, `Double`, etc.)
+   * @return
+   *   [[Right]] with the value if it is positive, otherwise [[Left]] with a [[DomainError.NegativeOrZero]] error.
+   *
+   * @example
+   *   {{{
+   * import io.github.srs.model.validation.Validation.*
+   *
+   * positive("width", 10)   // Right(10)
+   * positive("width", 0)    // Left(NegativeOrZero("width", 0.0))
+   *   }}}
+   */
   def positive[T](field: String, v: T)(using n: Numeric[T]): Validation[T] =
     Either.cond(
-      n.gt(v, n.zero),
-      v,
-      DomainError.NegativeOrZero(field, n.toDouble(v)),
+      n.gt(v, n.zero), // predicate
+      v, // happy path
+      DomainError.NegativeOrZero(field, n.toDouble(v)), // error
     )
+end Validation

--- a/src/test/scala/io/github/srs/model/StaticEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/StaticEntityTest.scala
@@ -40,6 +40,10 @@ class StaticEntityTest extends AnyFlatSpec:
     inside(StaticEntity.light(origin, orientation, radius, intensity, attenuation)):
       case Right(entity) => entity shouldBe expectedLight
 
+  it should "fail when radius is not positive" in:
+    val res = StaticEntity.light(origin, orientation, 0.0, intensity, attenuation)
+    inside(res.left.value) { case DomainError.NegativeOrZero("radius", _) => succeed }
+
   it should "fail when intensity is not positive" in:
     val res = StaticEntity.light(origin, orientation, radius, 0.0, attenuation)
     inside(res.left.value) { case DomainError.NegativeOrZero("intensity", _) => succeed }

--- a/src/test/scala/io/github/srs/model/StaticEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/StaticEntityTest.scala
@@ -40,3 +40,4 @@ class StaticEntityTest extends AnyFlatSpec:
     inside(res.left.value):
       case DomainError.NegativeOrZero(field, _) =>
         field shouldBe "attenuation"
+end StaticEntityTest

--- a/src/test/scala/io/github/srs/model/StaticEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/StaticEntityTest.scala
@@ -31,21 +31,21 @@ class StaticEntityTest extends AnyFlatSpec:
   it should "fail when width is not positive" in:
     val res = StaticEntity.obstacle(origin, orientation, 0, height)
     inside(res.left.value) { case DomainError.NegativeOrZero("width", _) => succeed }
-  
+
   it should "fail when height is not positive" in:
-      val res = StaticEntity.obstacle(origin, orientation, width, 0)
-      inside(res.left.value) { case DomainError.NegativeOrZero("height", _) => succeed }
-  
+    val res = StaticEntity.obstacle(origin, orientation, width, 0)
+    inside(res.left.value) { case DomainError.NegativeOrZero("height", _) => succeed }
+
   "light" should "create a valid entity" in:
     inside(StaticEntity.light(origin, orientation, radius, intensity, attenuation)):
       case Right(entity) => entity shouldBe expectedLight
-  
+
   it should "fail when intensity is not positive" in:
-      val res = StaticEntity.light(origin, orientation, radius, 0.0, attenuation)
-      inside(res.left.value) { case DomainError.NegativeOrZero("intensity", _) => succeed }
-  
+    val res = StaticEntity.light(origin, orientation, radius, 0.0, attenuation)
+    inside(res.left.value) { case DomainError.NegativeOrZero("intensity", _) => succeed }
+
   it should "fail when attenuation is not positive" in:
-      val res = StaticEntity.light(origin, orientation, radius, intensity, 0.0)
-      inside(res.left.value) { case DomainError.NegativeOrZero("attenuation", _) => succeed }
-  
+    val res = StaticEntity.light(origin, orientation, radius, intensity, 0.0)
+    inside(res.left.value) { case DomainError.NegativeOrZero("attenuation", _) => succeed }
+
 end StaticEntityTest

--- a/src/test/scala/io/github/srs/model/StaticEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/StaticEntityTest.scala
@@ -8,36 +8,44 @@ import org.scalatest.matchers.should.Matchers.*
 
 class StaticEntityTest extends AnyFlatSpec:
 
-  private val origin = Point2D(0, 0)
-  private val orient = Orientation(0)
+  given CanEqual[StaticEntity, StaticEntity] = CanEqual.derived
 
-  "obstacle" should "return Right when width and height are positive" in:
-    StaticEntity.obstacle(origin, orient, 2, 3).isRight shouldBe true
+  val origin: (Double, Double) = Point2D(0, 0)
+  val orientation: Orientation = Orientation(0)
 
-  "light" should "return Right when all parameters are positive" in:
-    StaticEntity.light(origin, orient, 1.0, 1.0, 1.0).isRight shouldBe true
+  // Obstacle
+  val width = 2
+  val height = 3
+  val expectedObstacle: StaticEntity = StaticEntity.Obstacle(origin, orientation, width, height)
+
+  // Light
+  val radius = 1.0
+  val intensity = 1.0
+  val attenuation = 1.0
+  val expectedLight: StaticEntity = StaticEntity.Light(origin, orientation, radius, intensity, attenuation)
+
+  "obstacle" should "create a valid entity" in:
+    inside(StaticEntity.obstacle(origin, orientation, width, height)):
+      case Right(entity) => entity shouldBe expectedObstacle
 
   it should "fail when width is not positive" in:
-    val res = StaticEntity.obstacle(origin, orient, 0, 3)
-    inside(res.left.value):
-      case DomainError.NegativeOrZero(field, _) =>
-        field shouldBe "width"
-
-  "obstacle" should "fail when height is not positive" in:
-    val res = StaticEntity.obstacle(origin, orient, 2, 0)
-    inside(res.left.value):
-      case DomainError.NegativeOrZero(field, _) =>
-        field shouldBe "height"
-
-  "light" should "fail when intensity is not positive" in:
-    val res = StaticEntity.light(origin, orient, 1.0, 0.0, 1.0)
-    inside(res.left.value):
-      case DomainError.NegativeOrZero(field, _) =>
-        field shouldBe "intensity"
-
+    val res = StaticEntity.obstacle(origin, orientation, 0, height)
+    inside(res.left.value) { case DomainError.NegativeOrZero("width", _) => succeed }
+  
+  it should "fail when height is not positive" in:
+      val res = StaticEntity.obstacle(origin, orientation, width, 0)
+      inside(res.left.value) { case DomainError.NegativeOrZero("height", _) => succeed }
+  
+  "light" should "create a valid entity" in:
+    inside(StaticEntity.light(origin, orientation, radius, intensity, attenuation)):
+      case Right(entity) => entity shouldBe expectedLight
+  
+  it should "fail when intensity is not positive" in:
+      val res = StaticEntity.light(origin, orientation, radius, 0.0, attenuation)
+      inside(res.left.value) { case DomainError.NegativeOrZero("intensity", _) => succeed }
+  
   it should "fail when attenuation is not positive" in:
-    val res = StaticEntity.light(origin, orient, 1.0, 1.0, 0.0)
-    inside(res.left.value):
-      case DomainError.NegativeOrZero(field, _) =>
-        field shouldBe "attenuation"
+      val res = StaticEntity.light(origin, orientation, radius, intensity, 0.0)
+      inside(res.left.value) { case DomainError.NegativeOrZero("attenuation", _) => succeed }
+  
 end StaticEntityTest

--- a/src/test/scala/io/github/srs/model/StaticEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/StaticEntityTest.scala
@@ -1,0 +1,42 @@
+package io.github.srs.model
+
+import io.github.srs.model.validation.DomainError
+import org.scalatest.EitherValues.*
+import org.scalatest.Inside.inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.*
+
+class StaticEntityTest extends AnyFlatSpec:
+
+  private val origin = Point2D(0, 0)
+  private val orient = Orientation(0)
+
+  "obstacle" should "return Right when width and height are positive" in:
+    StaticEntity.obstacle(origin, orient, 2, 3).isRight shouldBe true
+
+  "light" should "return Right when all parameters are positive" in:
+    StaticEntity.light(origin, orient, 1.0, 1.0, 1.0).isRight shouldBe true
+
+  it should "fail when width is not positive" in:
+    val res = StaticEntity.obstacle(origin, orient, 0, 3)
+    inside(res.left.value):
+      case DomainError.NegativeOrZero(field, _) =>
+        field shouldBe "width"
+
+  "obstacle" should "fail when height is not positive" in:
+    val res = StaticEntity.obstacle(origin, orient, 2, 0)
+    inside(res.left.value):
+      case DomainError.NegativeOrZero(field, _) =>
+        field shouldBe "height"
+
+  "light" should "fail when intensity is not positive" in:
+    val res = StaticEntity.light(origin, orient, 1.0, 0.0, 1.0)
+    inside(res.left.value):
+      case DomainError.NegativeOrZero(field, _) =>
+        field shouldBe "intensity"
+
+  it should "fail when attenuation is not positive" in:
+    val res = StaticEntity.light(origin, orient, 1.0, 1.0, 0.0)
+    inside(res.left.value):
+      case DomainError.NegativeOrZero(field, _) =>
+        field shouldBe "attenuation"

--- a/src/test/scala/io/github/srs/model/validation/ValidationTest.scala
+++ b/src/test/scala/io/github/srs/model/validation/ValidationTest.scala
@@ -1,0 +1,28 @@
+package io.github.srs.model.validation
+
+import io.github.srs.model.validation.Validation
+import org.scalatest.Inside.inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.shouldBe
+import org.scalatest.EitherValues.*
+
+class ValidationTest extends AnyFlatSpec:
+
+  "positive" should "accept positive Int" in :
+    Validation.positive("count", 7).value shouldBe 7
+
+  it should "accept positive Double" in :
+    Validation.positive("ratio", 3.14).value shouldBe 3.14
+
+  it should "reject zero Int" in :
+    inside(Validation.positive("count", 0)):
+      case Left(DomainError.NegativeOrZero("count", 0.0)) => succeed
+
+  it should "return reject zero Double" in :
+    inside(Validation.positive("ratio", 0.0)):
+      case Left(DomainError.NegativeOrZero("ratio", 0.0)) => succeed
+
+  it should "return reject negative Double" in :
+    inside(Validation.positive("ratio", -1.2)):
+      case Left(DomainError.NegativeOrZero("ratio", -1.2)) => succeed
+    

--- a/src/test/scala/io/github/srs/model/validation/ValidationTest.scala
+++ b/src/test/scala/io/github/srs/model/validation/ValidationTest.scala
@@ -8,21 +8,20 @@ import org.scalatest.EitherValues.*
 
 class ValidationTest extends AnyFlatSpec:
 
-  "positive" should "accept positive Int" in :
+  "positive" should "accept positive Int" in:
     Validation.positive("count", 7).value shouldBe 7
 
-  it should "accept positive Double" in :
+  it should "accept positive Double" in:
     Validation.positive("ratio", 3.14).value shouldBe 3.14
 
-  it should "reject zero Int" in :
+  it should "reject zero Int" in:
     inside(Validation.positive("count", 0)):
       case Left(DomainError.NegativeOrZero("count", 0.0)) => succeed
 
-  it should "return reject zero Double" in :
+  it should "return reject zero Double" in:
     inside(Validation.positive("ratio", 0.0)):
       case Left(DomainError.NegativeOrZero("ratio", 0.0)) => succeed
 
-  it should "return reject negative Double" in :
+  it should "return reject negative Double" in:
     inside(Validation.positive("ratio", -1.2)):
       case Left(DomainError.NegativeOrZero("ratio", -1.2)) => succeed
-    


### PR DESCRIPTION
This pull request introduces a new `StaticEntity` model to represent static objects in a simulation environment, along with domain-level validation utilities and comprehensive unit tests. The changes enhance the codebase's ability to model and validate entities like obstacles and light sources with domain-specific constraints.

### New Static Entity Model:

* **`StaticEntity` Enum and Companion Object**: Added `StaticEntity` to represent static entities (`Obstacle` and `Light`) with properties like position, orientation, and shape. Includes factory methods (`obstacle` and `light`) for safe creation with domain validation. (`src/main/scala/io/github/srs/model/StaticEntity.scala`, [src/main/scala/io/github/srs/model/StaticEntity.scalaR1-R123](diffhunk://#diff-e20ace340430a60c8d7d14586198e021f3f9f80292bc5a58a1c622c2b54e8332R1-R123))

### Domain Validation Utilities:

* **Validation Framework**: Introduced `Validation` type alias and `DomainError` ADT for domain-level validation. Added `positive` utility method to ensure numeric values are strictly positive, supporting domain constraints. (`src/main/scala/io/github/srs/model/validation/Validation.scala`, [src/main/scala/io/github/srs/model/validation/Validation.scalaR1-R46](diffhunk://#diff-2e35d8fba0e19ceab65f2b00a21c2f21a3967f7d3c39eeba31dd34822aba6998R1-R46))

### Unit Tests for Static Entity:

* **Static Entity Tests**: Added tests for `StaticEntity` creation and validation, ensuring correct behavior for valid inputs and proper error handling for invalid inputs. (`src/test/scala/io/github/srs/model/StaticEntityTest.scala`, [src/test/scala/io/github/srs/model/StaticEntityTest.scalaR1-R55](diffhunk://#diff-89dccbc521217e98a37c7f68e4d38d7119b3239650188b60089785f08eba3b0cR1-R55))

### Unit Tests for Validation Utilities:

* **Validation Tests**: Added tests for the `positive` method to verify its behavior across various numeric types and edge cases. (`src/test/scala/io/github/srs/model/validation/ValidationTest.scala`, [src/test/scala/io/github/srs/model/validation/ValidationTest.scalaR1-R27](diffhunk://#diff-1b85d97c823f4f2e4c0bc397e820a89064c1b12c758f82664ee88b5ee7ae929cR1-R27))