### PR TITLE
refactor: move validation externally from Point2D and Orientation

### DIFF
--- a/src/main/scala/io/github/srs/model/entity/Orientation.scala
+++ b/src/main/scala/io/github/srs/model/entity/Orientation.scala
@@ -1,8 +1,5 @@
 package io.github.srs.model.entity
 
-import io.github.srs.model.validation.Validation
-import io.github.srs.model.validation.Validation.*
-
 /**
  * Represents an orientation in a two-dimensional plane.
  *
@@ -53,11 +50,7 @@ object Orientation:
    * @return
    *   a new [[Orientation]] representing the given angle.
    */
-  def apply(degree: Double): Validation[Orientation] =
-    for
-      d <- notNaN("degree", degree)
-      d <- notInfinite("degree", d)
-    yield OrientationImpl(normalizeDegree(d))
+  def apply(degree: Double): Orientation = OrientationImpl(normalizeDegree(degree))
 
   /**
    * Creates a new [[Orientation]] instance from an angle in radians.
@@ -67,11 +60,7 @@ object Orientation:
    * @return
    *   a new [[Orientation]] representing the given angle.
    */
-  def fromRadians(radians: Double): Validation[Orientation] =
-    for
-      r <- notNaN("radians", radians)
-      r <- notInfinite("radians", r)
-    yield OrientationImpl(normalizeDegree(Math.toDegrees(r)))
+  def fromRadians(radians: Double): Orientation = OrientationImpl(normalizeDegree(Math.toDegrees(radians)))
 
   /**
    * Default implementation of [[Orientation]].

--- a/src/main/scala/io/github/srs/model/entity/Point2D.scala
+++ b/src/main/scala/io/github/srs/model/entity/Point2D.scala
@@ -1,8 +1,5 @@
 package io.github.srs.model.entity
 
-import io.github.srs.model.validation.Validation
-import io.github.srs.model.validation.Validation.{ notInfinite, notNaN }
-
 /**
  * Represents a point in a two-dimensional Cartesian coordinate system.
  *
@@ -25,13 +22,7 @@ object Point2D:
    * @return
    *   a new [[Point2D]] representing the given coordinates.
    */
-  def apply(x: Double, y: Double): Validation[Point2D] =
-    for
-      x <- notNaN("x", x)
-      x <- notInfinite("x", x)
-      y <- notNaN("y", y)
-      y <- notInfinite("y", y)
-    yield (x, y)
+  def apply(x: Double, y: Double): Point2D = (x, y)
 
 end Point2D
 

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/Robot.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/Robot.scala
@@ -73,8 +73,7 @@ object Robot:
       _ <- notInfinite("x", position.x)
       _ <- notNaN("y", position.y)
       _ <- notInfinite("y", position.y)
-      _ <- notNaN("degree", orientation.degrees)
-      _ <- notInfinite("degree", orientation.degrees)
+      _ <- notNaN("degrees", orientation.degrees)
       _ <- validateCountOfType[WheelMotor]("actuators", actuators, 0, 1)
     yield RobotImpl(position, shape, orientation, actuators)
 

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/Robot.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/Robot.scala
@@ -2,7 +2,7 @@ package io.github.srs.model.entity.dynamicentity
 
 import io.github.srs.model.entity.*
 import io.github.srs.model.validation.Validation
-import io.github.srs.model.validation.Validation.validateCountOfType
+import io.github.srs.model.validation.Validation.{ notInfinite, notNaN, validateCountOfType }
 
 /**
  * Represents a robot entity in the simulation.
@@ -68,7 +68,14 @@ object Robot:
       orientation: Orientation,
       actuators: Seq[Actuator[Robot]],
   ): Validation[Robot] =
-    for _ <- validateCountOfType[WheelMotor]("actuators", actuators, 0, 1)
+    for
+      _ <- notNaN("x", position.x)
+      _ <- notInfinite("x", position.x)
+      _ <- notNaN("y", position.y)
+      _ <- notInfinite("y", position.y)
+      _ <- notNaN("degree", orientation.degrees)
+      _ <- notInfinite("degree", orientation.degrees)
+      _ <- validateCountOfType[WheelMotor]("actuators", actuators, 0, 1)
     yield RobotImpl(position, shape, orientation, actuators)
 
   /**

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/WheelMotor.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/WheelMotor.scala
@@ -136,10 +136,9 @@ object WheelMotor:
       val theta = robot.orientation.toRadians
       val dx = velocity * math.cos(theta) * dt.toSeconds
       val dy = velocity * math.sin(theta) * dt.toSeconds
-      for
-        newPosition <- Point2D(robot.position.x + dx, robot.position.y + dy)
-        newOrientation <- Orientation.fromRadians(theta + omega * dt.toSeconds)
-        robot <- robot.copy(position = newPosition, orientation = newOrientation)
+      val newPosition = Point2D(robot.position.x + dx, robot.position.y + dy)
+      val newOrientation = Orientation.fromRadians(theta + omega * dt.toSeconds)
+      for robot <- robot.copy(position = newPosition, orientation = newOrientation)
       yield robot
 
   end DifferentialWheelMotor

--- a/src/test/scala/io/github/srs/model/entity/EntityTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/EntityTest.scala
@@ -3,13 +3,12 @@ package io.github.srs.model.entity
 import io.github.srs.model.entity.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import org.scalatest.OptionValues.convertOptionToValuable
 
 class EntityTest extends AnyFlatSpec with should.Matchers:
 
   "Entity trait" should "expose position, shape and orientation" in:
-    val p = Point2D(0.0, 0.0).toOption.value
-    val o = Orientation(0.0).toOption.value
+    val p = Point2D(0.0, 0.0)
+    val o = Orientation(0.0)
     class Dummy(val position: Point2D, val shape: ShapeType, val orientation: Orientation) extends Entity
 
     val e = Dummy(p, ShapeType.Circle(1.0), o)

--- a/src/test/scala/io/github/srs/model/entity/OrientationTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/OrientationTest.scala
@@ -1,6 +1,5 @@
 package io.github.srs.model.entity
 
-import io.github.srs.model.entity.Orientation
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/io/github/srs/model/entity/OrientationTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/OrientationTest.scala
@@ -1,16 +1,15 @@
 package io.github.srs.model.entity
 
 import io.github.srs.model.entity.Orientation
-import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should
+import org.scalatest.matchers.should.Matchers
 
-class OrientationTest extends AnyFlatSpec with should.Matchers:
+class OrientationTest extends AnyFlatSpec with Matchers:
 
   "Orientation" should "create an instance with the given degrees" in:
-    inside(Orientation(45.0)):
-      case Right(o) => o.degrees should be(45.0)
+    val orientation = Orientation(45.0)
+    orientation.degrees should be(45.0)
 
   it should "convert degrees to radians correctly" in:
-    inside(Orientation(90.0)):
-      case Right(o) => o.toRadians should be(math.Pi / 2 +- 1e-6)
+    val orientation = Orientation(90.0)
+    orientation.toRadians should be(math.Pi / 2 +- 1e-6)

--- a/src/test/scala/io/github/srs/model/entity/Point2DTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/Point2DTest.scala
@@ -1,26 +1,20 @@
 package io.github.srs.model.entity
 
 import io.github.srs.model.entity.*
-import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should
-import org.scalatest.OptionValues.convertOptionToValuable
+import org.scalatest.matchers.should.Matchers
 
-class Point2DTest extends AnyFlatSpec with should.Matchers:
+class Point2DTest extends AnyFlatSpec with Matchers:
 
   "Point2D" should "wrap coordinates into a tuple correctly" in:
-    inside(Point2D(1.0, 2.0)):
-      case Right(p) => p should be(Point2D(1.0, 2.0).toOption.value)
+    Point2D(1.0, 2.0) should be(Point2D(1.0, 2.0))
 
   it should "compute the correct Euclidean distance" in:
-    inside(Point2D(0.0, 0.0)):
-      case Right(p1) =>
-        inside(Point2D(3.0, 4.0)):
-          case Right(p2) => p1.distanceTo(p2) should be(5.0)
+    val p1: Point2D = Point2D(0.0, 0.0)
+    val p2: Point2D = Point2D(3.0, 4.0)
+    p1.distanceTo(p2) should be(5.0)
 
   it should "be symmetric: distance from p1 to p2 equals distance from p2 to p1" in:
-    inside(Point2D(0.0, 0.0)):
-      case Right(p1) =>
-        inside(Point2D(3.0, 4.0)):
-          case Right(p2) =>
-            p1.distanceTo(p2) should be(p2.distanceTo(p1))
+    val p1: Point2D = Point2D(0.0, 0.0)
+    val p2: Point2D = Point2D(3.0, 4.0)
+    p1.distanceTo(p2) should be(p2.distanceTo(p1))

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/DynamicEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/DynamicEntityTest.scala
@@ -4,12 +4,11 @@ import io.github.srs.model.entity.{ Orientation, Point2D, ShapeType }
 import io.github.srs.model.validation.{ DomainError, Validation }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.OptionValues.convertOptionToValuable
 
 class DynamicEntityTest extends AnyFlatSpec with Matchers:
 
-  val initialPosition: Point2D = Point2D(0.0, 0.0).toOption.value
-  val initialOrientation: Orientation = Orientation(0.0).toOption.value
+  val initialPosition: Point2D = Point2D(0.0, 0.0)
+  val initialOrientation: Orientation = Orientation(0.0)
   val shape: ShapeType.Circle = ShapeType.Circle(0.5)
 
   class Dummy(

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
@@ -11,8 +11,8 @@ import org.scalatest.matchers.should.Matchers
 
 class RobotTest extends AnyFlatSpec with Matchers:
 
-  val initialPosition: Point2D = Point2D(0.0, 0.0).toOption.value
-  val initialOrientation: Orientation = Orientation(0.0).toOption.value
+  val initialPosition: Point2D = Point2D(0.0, 0.0)
+  val initialOrientation: Orientation = Orientation(0.0)
   val shape: ShapeType.Circle = ShapeType.Circle(0.5)
 
   val wheelMotor: WheelMotor =

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
@@ -3,7 +3,6 @@ package io.github.srs.model.entity.dynamicentity
 import io.github.srs.model.entity.*
 import io.github.srs.model.entity.dynamicentity.WheelMotor.{ applyActions, move }
 import io.github.srs.model.entity.dynamicentity.WheelMotorTestUtils.calculateMovement
-import io.github.srs.model.validation.DomainError
 import org.scalatest.Inside.inside
 import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.flatspec.AnyFlatSpec
@@ -22,17 +21,13 @@ class RobotTest extends AnyFlatSpec with Matchers:
     inside(Robot(initialPosition, shape, initialOrientation, Seq.empty)):
       case Right(robot) => robot.position should be(initialPosition)
 
-  it should "support having no actuators" in:
+  it should "support having sequence empty of actuators" in:
     inside(Robot(initialPosition, shape, initialOrientation, Seq.empty)):
       case Right(robot) => robot.actuators should be(Seq.empty)
 
   it should "support having one WheelMotor Actuator" in:
     inside(Robot(initialPosition, shape, initialOrientation, Seq(wheelMotor))):
       case Right(robot) => robot.actuators should be(Seq(wheelMotor))
-
-  it should "not support having multiple WheelMotor Actuators" in:
-    inside(Robot(initialPosition, shape, initialOrientation, Seq(wheelMotor, wheelMotor))):
-      case Left(DomainError.InvalidCount("actuators", 2, 0, 1)) => succeed
 
   it should "stay at the same position if no movement occurs" in:
     inside(Robot(initialPosition, shape, initialOrientation, Seq(wheelMotor))):

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotValidationTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotValidationTest.scala
@@ -1,0 +1,38 @@
+package io.github.srs.model.entity.dynamicentity
+
+import io.github.srs.model.entity.*
+import io.github.srs.model.validation.DomainError
+import org.scalatest.Inside.inside
+import org.scalatest.OptionValues.convertOptionToValuable
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RobotValidationTest extends AnyFlatSpec with Matchers:
+
+  val initialPosition: Point2D = Point2D(0.0, 0.0)
+  val initialOrientation: Orientation = Orientation(0.0)
+  val shape: ShapeType.Circle = ShapeType.Circle(0.5)
+
+  val wheelMotor: WheelMotor =
+    WheelMotor(DeltaTime(0.1).toOption.value, Wheel(1.0, ShapeType.Circle(0.5)), Wheel(1.0, ShapeType.Circle(0.5)))
+
+  it should "not support having multiple WheelMotor Actuators" in:
+    inside(Robot(initialPosition, shape, initialOrientation, Seq(wheelMotor, wheelMotor))):
+      case Left(DomainError.InvalidCount("actuators", 2, 0, 1)) => succeed
+
+  it should "not support having NaN position" in:
+    inside(Robot(Point2D(Double.NaN, 0.0), shape, initialOrientation, Seq(wheelMotor))):
+      case Left(DomainError.NotANumber("x", value)) => assert(value.isNaN)
+
+  it should "not support having Infinite position" in:
+    inside(Robot(Point2D(0.0, Double.PositiveInfinity), shape, initialOrientation, Seq(wheelMotor))):
+      case Left(DomainError.Infinite("y", value)) => assert(value.isInfinite)
+
+  it should "not support having NaN orientation" in:
+    inside(Robot(initialPosition, shape, Orientation(Double.NaN), Seq(wheelMotor))):
+      case Left(DomainError.NotANumber("degrees", value)) => assert(value.isNaN)
+
+  it should "not support having Infinite orientation" in:
+    inside(Robot(initialPosition, shape, Orientation(Double.NegativeInfinity), Seq(wheelMotor))):
+      case Left(DomainError.NotANumber("degrees", value)) => assert(value.isNaN)
+end RobotValidationTest

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotValidationTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotValidationTest.scala
@@ -31,8 +31,4 @@ class RobotValidationTest extends AnyFlatSpec with Matchers:
   it should "not support having NaN orientation" in:
     inside(Robot(initialPosition, shape, Orientation(Double.NaN), Seq(wheelMotor))):
       case Left(DomainError.NotANumber("degrees", value)) => assert(value.isNaN)
-
-  it should "not support having Infinite orientation" in:
-    inside(Robot(initialPosition, shape, Orientation(Double.NegativeInfinity), Seq(wheelMotor))):
-      case Left(DomainError.NotANumber("degrees", value)) => assert(value.isNaN)
 end RobotValidationTest

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/WheelMotorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/WheelMotorTest.scala
@@ -12,8 +12,8 @@ class WheelMotorTest extends AnyFlatSpec with Matchers:
   val dt: DeltaTime = DeltaTime(0.1).toOption.value
   val wheelRadius: Double = 0.5
   val shape: ShapeType.Circle = ShapeType.Circle(1.0)
-  val initialPosition: Point2D = Point2D(0.0, 0.0).toOption.value
-  val initialOrientation: Orientation = Orientation(0.0).toOption.value
+  val initialPosition: Point2D = Point2D(0.0, 0.0)
+  val initialOrientation: Orientation = Orientation(0.0)
 
   "WheelMotor" should "update its position based on the wheel speeds" in:
     val leftSpeed: Double = 1.0

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/WheelMotorTestUtils.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/WheelMotorTestUtils.scala
@@ -1,8 +1,6 @@
 package io.github.srs.model.entity.dynamicentity
 
-import io.github.srs.model.entity.{ Orientation, Point2D }
 import io.github.srs.model.entity.*
-import org.scalatest.OptionValues.convertOptionToValuable
 
 object WheelMotorTestUtils:
 
@@ -18,7 +16,7 @@ object WheelMotorTestUtils:
         val dx = velocity * math.cos(theta) * wm.dt.toSeconds
         val dy = velocity * math.sin(theta) * wm.dt.toSeconds
         (
-          Point2D(robot.position.x + dx, robot.position.y + dy).toOption.value,
-          Orientation.fromRadians(theta + omega * wm.dt.toSeconds).toOption.value,
+          Point2D(robot.position.x + dx, robot.position.y + dy),
+          Orientation.fromRadians(theta + omega * wm.dt.toSeconds),
         )
       case None => (robot.position, robot.orientation)

--- a/src/test/scala/io/github/srs/model/entity/staticentity/StaticEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/staticentity/StaticEntityTest.scala
@@ -7,14 +7,13 @@ import org.scalatest.EitherValues.*
 import org.scalatest.Inside.inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.*
-import org.scalatest.OptionValues.convertOptionToValuable
 
 class StaticEntityTest extends AnyFlatSpec:
 
   given CanEqual[StaticEntity, StaticEntity] = CanEqual.derived
 
-  val origin: (Double, Double) = Point2D(0, 0).toOption.value
-  val orientation: Orientation = Orientation(0).toOption.value
+  val origin: (Double, Double) = Point2D(0, 0)
+  val orientation: Orientation = Orientation(0)
 
   // Obstacle
   val width = 2

--- a/src/test/scala/io/github/srs/model/environment/EnvironmentTest.scala
+++ b/src/test/scala/io/github/srs/model/environment/EnvironmentTest.scala
@@ -1,12 +1,11 @@
 package io.github.srs.model.environment
 
 import io.github.srs.model.entity.*
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should
 import org.scalatest.Inside.inside
-import org.scalatest.OptionValues.convertOptionToValuable
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EnvironmentTest extends AnyFlatSpec with should.Matchers:
+class EnvironmentTest extends AnyFlatSpec with Matchers:
   given CanEqual[Entity, Entity] = CanEqual.derived
 
   private def createEntity(p: (Double, Double), s: ShapeType, o: Orientation): Entity =
@@ -24,13 +23,13 @@ class EnvironmentTest extends AnyFlatSpec with should.Matchers:
       case Right(environment) => environment.entities should be(Set.empty)
 
   it should "allow adding entities" in:
-    val entity1 = createEntity((1.0, 1.0), ShapeType.Circle(1.0), Orientation(0.0).toOption.value)
-    val entity2 = createEntity((1.0, 1.0), ShapeType.Rectangle(2.0, 3.0), Orientation(90.0).toOption.value)
+    val entity1 = createEntity((1.0, 1.0), ShapeType.Circle(1.0), Orientation(0.0))
+    val entity2 = createEntity((1.0, 1.0), ShapeType.Rectangle(2.0, 3.0), Orientation(90.0))
     inside(Environment(10, 10, Set(entity1, entity2))):
       case Right(environment) => environment.entities should contain theSameElementsAs Set(entity1, entity2)
 
   it should "extract environment fields correctly" in:
-    val entity = createEntity((5.0, 5.0), ShapeType.Circle(2.0), Orientation(45.0).toOption.value)
+    val entity = createEntity((5.0, 5.0), ShapeType.Circle(2.0), Orientation(45.0))
     inside(Environment(20, 15, Set(entity))):
       case Right(environment) =>
         val result = environment match


### PR DESCRIPTION
This pull request refactors the creation of `Orientation` and `Point2D` instances by removing the use of the Validation type from their constructors, thereby simplifying their internal logic. The associated tests have been updated accordingly, and unused imports have been removed.

These changes streamline the codebase by moving validation responsibilities outside of the `Orientation` and `Point2D` constructors, making them more focused and easier to maintain. Validation is still performed in the appropriate higher-level logic and test cases to ensure correctness.