### PR TITLE
feat: mvc with generic state and simulation loop

### DIFF
--- a/src/main/scala/io/github/srs/Launcher.scala
+++ b/src/main/scala/io/github/srs/Launcher.scala
@@ -20,7 +20,7 @@ object Launcher
 
   val model: Model[SimulationState] = Model(s =>
     if s.i >= MaxIterations then None
-    else Some(s.copy(s.i + 1)),
+    else Some(s.copy(i = s.i + 1)),
   )
   val view: View[SimulationState] = View()
   val controller: Controller[SimulationState] = Controller()

--- a/src/main/scala/io/github/srs/Launcher.scala
+++ b/src/main/scala/io/github/srs/Launcher.scala
@@ -16,7 +16,12 @@ object Launcher
     with ViewModule.Interface[SimulationState]
     with ControllerModule.Interface[SimulationState]:
 
-  val model: Model[SimulationState] = Model(s => Some(s.copy(s.i + 1)))
+  private val MaxIterations = 10_000_000
+
+  val model: Model[SimulationState] = Model(s =>
+    if s.i >= MaxIterations then None
+    else Some(s.copy(s.i + 1)),
+  )
   val view: View[SimulationState] = View()
   val controller: Controller[SimulationState] = Controller()
 

--- a/src/main/scala/io/github/srs/Launcher.scala
+++ b/src/main/scala/io/github/srs/Launcher.scala
@@ -4,14 +4,18 @@ import io.github.srs.controller.ControllerModule
 import io.github.srs.controller.ControllerModule.Controller
 import io.github.srs.model.ModelModule
 import io.github.srs.model.ModelModule.Model
+import io.github.srs.model.SimulationState.SimulationState
 import io.github.srs.view.ViewModule
 import io.github.srs.view.ViewModule.View
 
-object Launcher extends ModelModule.Interface with ViewModule.Interface with ControllerModule.Interface:
+object Launcher
+    extends ModelModule.Interface[SimulationState]
+    with ViewModule.Interface[SimulationState]
+    with ControllerModule.Interface[SimulationState]:
 
-  val model: Model = Model()
-  val view: View = View()
-  val controller: Controller = Controller()
+  val model: Model[SimulationState] = Model(s => Some(s.copy(s.i + 1)))
+  val view: View[SimulationState] = View()
+  val controller: Controller[SimulationState] = Controller()
 
   @main def run(): Unit =
-    controller.start()
+    controller.start(SimulationState(0))

--- a/src/main/scala/io/github/srs/Launcher.scala
+++ b/src/main/scala/io/github/srs/Launcher.scala
@@ -8,6 +8,9 @@ import io.github.srs.model.SimulationState.SimulationState
 import io.github.srs.view.ViewModule
 import io.github.srs.view.ViewModule.View
 
+/**
+ * Launcher object that initializes the simulation.
+ */
 object Launcher
     extends ModelModule.Interface[SimulationState]
     with ViewModule.Interface[SimulationState]

--- a/src/main/scala/io/github/srs/controller/ControllerModule.scala
+++ b/src/main/scala/io/github/srs/controller/ControllerModule.scala
@@ -2,30 +2,80 @@ package io.github.srs.controller
 
 import io.github.srs.model.ModelModule
 
+/**
+ * Module that defines the controller logic for the Scala Robotics Simulator.
+ */
 object ControllerModule:
 
+  /**
+   * Controller trait that defines the interface for the controller.
+   *
+   * @tparam S
+   *   the type of the state, which must extend [[ModelModule.State]].
+   */
   trait Controller[S <: ModelModule.State]:
+    /**
+     * Starts the controller with the initial state.
+     *
+     * @param initialState
+     *   the initial state of the simulation.
+     */
     def start(initialState: S): Unit
+
+    /**
+     * Runs the simulation loop, updating the state and rendering the view.
+     * @param s
+     *   the current state of the simulation.
+     */
     def simulationLoop(s: S): Unit
 
+  /**
+   * Provider trait that defines the interface for providing a controller.
+   * @tparam S
+   *   the type of the state, which must extend [[ModelModule.State]].
+   */
   trait Provider[S <: ModelModule.State]:
     val controller: Controller[S]
 
+  /**
+   * Defines the dependencies required by the controller module. In particular, it requires a
+   * [[io.github.srs.view.ViewModule.Provider]] and a [[io.github.srs.model.ModelModule.Provider]].
+   */
   type Requirements[S <: ModelModule.State] =
     io.github.srs.view.ViewModule.Provider[S] & io.github.srs.model.ModelModule.Provider[S]
 
+  /**
+   * Component trait that defines the interface for creating a controller.
+   * @tparam S
+   *   the type of the simulation state, which must extend [[ModelModule.State]].
+   */
   trait Component[S <: ModelModule.State]:
     context: Requirements[S] =>
 
     object Controller:
+      /**
+       * Creates a controller instance.
+       *
+       * @return
+       *   a [[Controller]] instance.
+       */
       def apply(): Controller[S] = new ControllerImpl
 
+      /**
+       * Private controller implementation that delegates the simulation loop to the provided model and view.
+       */
       private class ControllerImpl extends Controller[S]:
 
+        /**
+         * @inheritdoc
+         */
         override def start(initialState: S): Unit =
           context.view.init()
           simulationLoop(initialState)
 
+        /**
+         * @inheritdoc
+         */
         @annotation.tailrec
         override final def simulationLoop(s: S): Unit =
           val state = for
@@ -36,9 +86,17 @@ object ControllerModule:
           state match
             case Some(ns) => simulationLoop(ns)
             case None => ()
+      end ControllerImpl
+    end Controller
 
   end Component
 
+  /**
+   * Interface trait that combines the provider and component traits for the controller module.
+   *
+   * @tparam S
+   *   the type of the simulation state, which must extend [[ModelModule.State]].
+   */
   trait Interface[S <: ModelModule.State] extends Provider[S] with Component[S]:
     self: Requirements[S] =>
 end ControllerModule

--- a/src/main/scala/io/github/srs/model/ModelModule.scala
+++ b/src/main/scala/io/github/srs/model/ModelModule.scala
@@ -1,21 +1,72 @@
 package io.github.srs.model
 
+/**
+ * Module that defines the model logic for the Scala Robotics Simulator.
+ */
 object ModelModule:
 
+  /**
+   * State trait that defines the base state for the simulation.
+   */
   trait State
 
+  /**
+   * Trait representing the core model logic for updating the simulation state.
+   *
+   * @tparam S
+   *   the type of the simulation state, which must extend [[State]].
+   */
   trait Model[S <: State]:
+    /**
+     * Updates the state of the simulation.
+     *
+     * @param s
+     *   the current state of the simulation.
+     * @return
+     *   an optional new state, or None if the simulation should end.
+     */
     def update(s: S): Option[S]
 
+  /**
+   * Provider trait that defines the interface for providing a model.
+   * @tparam S
+   *   the type of the state, which must extend [[State]].
+   */
   trait Provider[S <: State]:
     val model: Model[S]
 
+  /**
+   * Component trait that defines the interface for creating a model.
+   *
+   * @tparam S
+   *   the type of the simulation state, which must extend [[State]].
+   */
   trait Component[S <: State]:
 
     object Model:
+      /**
+       * Creates a model from the provided update function.
+       *
+       * @param updateFunc
+       *   a function that defines how the state is updated.
+       * @return
+       *   a [[Model]] instance using the given update logic.
+       */
       def apply(updateFunc: S => Option[S]): Model[S] = new ModelImpl(updateFunc)
 
+      /**
+       * Private model implementation that delegates state updates to the provided function.
+       */
       private class ModelImpl(updateFunc: S => Option[S]) extends Model[S]:
+        /**
+         * @inheritdoc
+         */
         override def update(s: S): Option[S] = updateFunc(s)
 
+  /**
+   * Interface trait that combines the provider and component traits.
+   * @tparam S
+   *   the type of the state, which must extend [[State]].
+   */
   trait Interface[S <: State] extends Provider[S] with Component[S]
+end ModelModule

--- a/src/main/scala/io/github/srs/model/ModelModule.scala
+++ b/src/main/scala/io/github/srs/model/ModelModule.scala
@@ -2,18 +2,20 @@ package io.github.srs.model
 
 object ModelModule:
 
-  trait Model:
-    def getData: Int
+  trait State
 
-  trait Provider:
-    val model: Model
+  trait Model[S <: State]:
+    def update(s: S): Option[S]
 
-  trait Component:
+  trait Provider[S <: State]:
+    val model: Model[S]
+
+  trait Component[S <: State]:
 
     object Model:
-      def apply(): Model = new ModelImpl()
+      def apply(updateFunc: S => Option[S]): Model[S] = new ModelImpl(updateFunc)
 
-      private class ModelImpl extends Model:
-        def getData: Int = 1
+      private class ModelImpl(updateFunc: S => Option[S]) extends Model[S]:
+        override def update(s: S): Option[S] = updateFunc(s)
 
-  trait Interface extends Provider with Component
+  trait Interface[S <: State] extends Provider[S] with Component[S]

--- a/src/main/scala/io/github/srs/model/ModelModule.scala
+++ b/src/main/scala/io/github/srs/model/ModelModule.scala
@@ -62,6 +62,7 @@ object ModelModule:
          * @inheritdoc
          */
         override def update(s: S): Option[S] = updateFunc(s)
+  end Component
 
   /**
    * Interface trait that combines the provider and component traits.

--- a/src/main/scala/io/github/srs/model/SimulationState.scala
+++ b/src/main/scala/io/github/srs/model/SimulationState.scala
@@ -1,0 +1,4 @@
+package io.github.srs.model
+
+object SimulationState:
+  final case class SimulationState(i: Int) extends ModelModule.State

--- a/src/main/scala/io/github/srs/view/SimpleView.scala
+++ b/src/main/scala/io/github/srs/view/SimpleView.scala
@@ -3,7 +3,9 @@ package io.github.srs.view
 import javax.swing.*
 import java.awt.*
 
-class SimpleView:
+import io.github.srs.model.ModelModule
+
+class SimpleView[S <: ModelModule.State]:
   private val frame = new JFrame("Scala Robotics Simulator")
   private val lblText = new JLabel("Hello World!", SwingConstants.CENTER)
 
@@ -17,8 +19,8 @@ class SimpleView:
   private def setLabelText(text: String): Unit =
     lblText.setText(text)
 
-  def plotData(data: Int): Unit =
-    setLabelText(s"${lblText.getText} ${data.toString}")
+  def render(state: S): Unit =
+    setLabelText(s"$state")
 
   def close(): Unit =
     frame.dispose()

--- a/src/main/scala/io/github/srs/view/ViewModule.scala
+++ b/src/main/scala/io/github/srs/view/ViewModule.scala
@@ -1,28 +1,31 @@
 package io.github.srs.view
 
+import io.github.srs.model.ModelModule
+
 object ViewModule:
 
-  trait View:
+  trait View[S <: ModelModule.State]:
     def init(): Unit
-    def plotData(data: Int): Unit
+    def render(state: S): Unit
 
-  trait Provider:
-    val view: View
+  trait Provider[S <: ModelModule.State]:
+    val view: View[S]
 
-  type Requirements = io.github.srs.controller.ControllerModule.Provider
+  type Requirements[S <: ModelModule.State] = io.github.srs.controller.ControllerModule.Provider[S]
 
-  trait Component:
-    context: Requirements =>
+  trait Component[S <: ModelModule.State]:
+    context: Requirements[S] =>
 
     object View:
-      def apply(): View = new ViewImpl
+      def apply(): View[S] = new ViewImpl
 
-      private class ViewImpl extends View:
-        private val gui = new SimpleView
+      private class ViewImpl extends View[S]:
+        private val gui = new SimpleView[S]
 
-        def init(): Unit = gui.init()
-        def plotData(data: Int): Unit = gui.plotData(data)
+        override def init(): Unit = gui.init()
 
-  trait Interface extends Provider with Component:
-    self: Requirements =>
+        override def render(state: S): Unit = gui.render(state)
+
+  trait Interface[S <: ModelModule.State] extends Provider[S] with Component[S]:
+    self: Requirements[S] =>
 end ViewModule

--- a/src/main/scala/io/github/srs/view/ViewModule.scala
+++ b/src/main/scala/io/github/srs/view/ViewModule.scala
@@ -2,30 +2,91 @@ package io.github.srs.view
 
 import io.github.srs.model.ModelModule
 
+/**
+ * Module that defines the view logic for the Scala Robotics Simulator.
+ */
 object ViewModule:
 
+  /**
+   * View trait that defines the interface for the view.
+   *
+   * @tparam S
+   *   the type of the state, which must extend [[ModelModule.State]].
+   */
   trait View[S <: ModelModule.State]:
+    /**
+     * Initializes the view.
+     */
     def init(): Unit
+
+    /**
+     * Renders the view based on the current state.
+     *
+     * @param state
+     *   the current state of the simulation.
+     */
     def render(state: S): Unit
 
+  /**
+   * Provider trait that defines the interface for providing a view.
+   * @tparam S
+   *   the type of the state, which must extend [[ModelModule.State]].
+   */
   trait Provider[S <: ModelModule.State]:
     val view: View[S]
 
+  /**
+   * Defines the dependencies required by the view module. In particular, it requires a
+   * [[io.github.srs.controller.ControllerModule.Provider]].
+   */
   type Requirements[S <: ModelModule.State] = io.github.srs.controller.ControllerModule.Provider[S]
 
+  /**
+   * Component trait that defines the interface for creating a view.
+   *
+   * @tparam S
+   *   the type of the simulation state, which must extend [[ModelModule.State]].
+   */
   trait Component[S <: ModelModule.State]:
     context: Requirements[S] =>
 
     object View:
+      /**
+       * Creates a view instance.
+       *
+       * @return
+       *   a [[View]] instance.
+       */
       def apply(): View[S] = new ViewImpl
 
+      /**
+       * Private view implementation that uses a simple GUI.
+       */
       private class ViewImpl extends View[S]:
         private val gui = new SimpleView[S]
 
+        /**
+         * Initializes the GUI.
+         */
         override def init(): Unit = gui.init()
 
+        /**
+         * Renders the GUI based on the current state.
+         *
+         * @param state
+         *   the current state of the simulation.
+         */
         override def render(state: S): Unit = gui.render(state)
 
+    end View
+
+  end Component
+
+  /**
+   * Interface trait that combines the provider and component traits for the view module.
+   * @tparam S
+   *   the type of the state, which must extend [[ModelModule.State]].
+   */
   trait Interface[S <: ModelModule.State] extends Provider[S] with Component[S]:
     self: Requirements[S] =>
 end ViewModule


### PR DESCRIPTION
This pull request refactors the Scala Robotics Simulator to introduce a generic simulation state (`SimulationState`) and updates the architecture to use type parameters for state management across the `ModelModule`, `ViewModule`, and `ControllerModule`. The changes improve modularity, scalability, and type safety by adopting a more functional and type-driven design.

Additionally, a `simulationLoop` method has been added to the `ControllerModule`, implemented as a tail-recursive function that updates and renders the simulation state until termination.