### PR TITLE
feat: implement light sensors

### DIFF
--- a/src/main/resources/configuration.yml
+++ b/src/main/resources/configuration.yml
@@ -32,4 +32,4 @@ environment:
         radius: 0.5
         speed: 1.0
         withProximitySensors: true
-        withLightSensors: false
+        withLightSensors: true

--- a/src/main/scala/io/github/srs/config/yaml/parser/YamlSimulationConfigParser.scala
+++ b/src/main/scala/io/github/srs/config/yaml/parser/YamlSimulationConfigParser.scala
@@ -230,8 +230,7 @@ object YamlSimulationConfigParser:
   private def parseProximitySensor(map: Map[String, Any]): ConfigResult[Sensor[Robot, Environment]] =
     for
       offset <- get[Double]("offset", map)
-      distance <- get[Double]("distance", map)
       range <- get[Double]("range", map)
-    yield proximitySensor withOffset Orientation(offset) withDistance distance withRange range
+    yield proximitySensor withOffset Orientation(offset) withRange range
 
 end YamlSimulationConfigParser

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Sensor.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Sensor.scala
@@ -27,7 +27,6 @@ object Sensor:
   given Encoder[ProximitySensor[?, ?]] = (sensor: ProximitySensor[?, ?]) =>
     Json.obj(
       "offset" -> sensor.offset.degrees.asJson,
-      "distance" -> sensor.distance.asJson,
       "range" -> sensor.range.asJson,
     )
 end Sensor

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDsl.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDsl.scala
@@ -83,7 +83,7 @@ object RobotDsl:
      *   a new [[Robot]] instance with the updated sensors.
      */
     infix def withSensors(sensors: Seq[Sensor[Robot, Environment]]): Robot =
-      robot.copy(sensors = sensors.toVector)
+      robot.copy(sensors = robot.sensors ++ sensors.toVector)
 
     /**
      * Adds an actuator to the robot.
@@ -156,7 +156,7 @@ object RobotDsl:
       robot.withSensors(stdProximitySensors)
 
     def withLightSensors: Robot =
-      robot // TODO: Implement light sensors when available
+      robot.withSensors(stdLightSensors)
 
     /**
      * Validates the robot entity to ensure it meets the domain constraints.

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/sensor/Sensor.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/sensor/Sensor.scala
@@ -1,6 +1,5 @@
 package io.github.srs.model.entity.dynamicentity.sensor
 
-import cats.Monad
 import cats.syntax.all.*
 import io.github.srs.model.PositiveDouble
 import io.github.srs.model.entity.dynamicentity.{ DynamicEntity, Robot }
@@ -9,6 +8,10 @@ import io.github.srs.model.environment.Environment
 import io.github.srs.model.validation.Validation
 import io.github.srs.utils.Ray.intersectRay
 import io.github.srs.utils.SimulationDefaults.DynamicEntity.Sensor.ProximitySensor as ProximitySensorDefaults
+import io.github.srs.model.illumination.LightMap
+import io.github.srs.model.illumination.engine.SquidLibFovEngine
+import io.github.srs.model.illumination.model.ScaleFactor
+import cats.effect.kernel.Sync
 
 /**
  * Represents the range of a sensor.
@@ -62,14 +65,12 @@ trait Sensor[-Entity <: DynamicEntity, -Env <: Environment]:
    *   the dynamic entity that the sensor is attached to.
    * @param env
    *   the environment in which the sensor operates.
-   * @param x$3
-   *   the implicit Monad instance for the effect type `F`.
    * @tparam F
    *   the effect type in which the sensing operation is performed.
    * @return
    *   a monadic effect containing the data sensed by the sensor.
    */
-  def sense[F[_]](entity: Entity, env: Env)(using Monad[F]): F[Data]
+  def sense[F[_]: Sync](entity: Entity, env: Env): F[Data]
 end Sensor
 
 /**
@@ -114,21 +115,65 @@ final case class ProximitySensor[Entity <: DynamicEntity, Env <: Environment](
 
   override type Data = Double
 
-  override def sense[F[_]](entity: Entity, env: Env)(using Monad[F]): F[Data] =
+  override def sense[F[_]: Sync](entity: Entity, env: Env): F[Data] =
+    Sync[F].pure:
+      import Point2D.*
+      val globalOrientation = entity.orientation.toRadians + offset.toRadians
+      val direction = Point2D(math.cos(globalOrientation), -math.sin(globalOrientation))
+      val origin = entity.position + direction * distance
+      val end = origin + direction * range
+
+      val distances = env.entities
+        .filter(!_.equals(entity))
+        .flatMap(intersectRay(_, origin, end))
+        .filter(_ <= range)
+
+      distances.minOption.map(_ / range).getOrElse(1.0)
+
+end ProximitySensor
+
+/**
+ * A light sensor that senses the light intensity in the environment.
+ * @param offset
+ *   the offset orientation of the sensor relative to the entity's orientation.
+ * @param distance
+ *   the distance from the center of the entity to the sensor.
+ * @param range
+ *   the range of the sensor, which defines how far it can sense.
+ * @tparam Entity
+ *   the type of dynamic entity that the sensor can act upon.
+ * @tparam Env
+ *   the type of environment in which the sensor operates.
+ */
+final case class LightSensor[Entity <: DynamicEntity, Env <: Environment](
+    offset: Orientation = Orientation(ProximitySensorDefaults.defaultOffset),
+    distance: Distance = ProximitySensorDefaults.defaultDistance,
+    range: Range = ProximitySensorDefaults.defaultRange,
+) extends Sensor[Entity, Env]:
+
+  override type Data = Double
+
+  /**
+   * Senses the light intensity at the position of the sensor in the environment. It uses a cached light map to compute
+   * the field of light and samples it at the sensor's position.
+   * @param entity
+   *   the dynamic entity that the sensor is attached to.
+   * @param env
+   *   the environment in which the sensor operates.
+   * @return
+   *   a monadic effect containing the light intensity sensed by the sensor.
+   */
+  override def sense[F[_]: Sync](entity: Entity, env: Env): F[Data] =
     import Point2D.*
     val globalOrientation = entity.orientation.toRadians + offset.toRadians
     val direction = Point2D(math.cos(globalOrientation), -math.sin(globalOrientation))
     val origin = entity.position + direction * distance
-    val end = origin + direction * range
+    for
+      lightMap <- LightMap.cached[F](SquidLibFovEngine, ScaleFactor.default)
+      field <- lightMap.computeField(env = env, includeDynamic = true)
+    yield field.sampleAtWorld(origin)(using ScaleFactor.default)
 
-    val distances = env.entities
-      .filter(!_.equals(entity))
-      .flatMap(intersectRay(_, origin, end))
-      .filter(_ <= range)
-
-    summon[Monad[F]].pure(distances.minOption.map(_ / range).getOrElse(1.0))
-
-end ProximitySensor
+end LightSensor
 
 object Sensor:
 
@@ -152,7 +197,7 @@ object Sensor:
      * @return
      *   a vector of sensor readings.
      */
-    def senseAll[F[_]: Monad](env: Environment): F[SensorReadings] =
+    def senseAll[F[_]: Sync](env: Environment): F[SensorReadings] =
       r.sensors.traverse: sensor =>
         sensor.sense(r, env).map(reading => SensorReading(sensor, reading))
 end Sensor

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/sensor/dsl/ProximitySensorDsl.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/sensor/dsl/ProximitySensorDsl.scala
@@ -24,16 +24,6 @@ object ProximitySensorDsl:
       sensor.copy(range = range)
 
     /**
-     * Sets the distance from the center of the entity to the sensor.
-     * @param distance
-     *   the distance from the entity's center to the sensor.
-     * @return
-     *   a new [[ProximitySensor]] instance with the updated distance.
-     */
-    infix def withDistance(distance: Double): ProximitySensor[DynamicEntity, Environment] =
-      sensor.copy(distance = distance)
-
-    /**
      * Sets the offset orientation of the sensor relative to the entity's orientation.
      * @param offset
      *   the orientation offset of the sensor.

--- a/src/main/scala/io/github/srs/model/illumination/model/ScaleFactor.scala
+++ b/src/main/scala/io/github/srs/model/illumination/model/ScaleFactor.scala
@@ -26,6 +26,14 @@ object ScaleFactor:
     bounded("ScaleFactor", n, 1, 1000, includeMax = true).map(v => v: ScaleFactor)
 
   /**
+   * Returns the default scale factor of 100 cells per meter.
+   *
+   * @return
+   *   The default scale factor as an [[ScaleFactor]].
+   */
+  def default: ScaleFactor = 100
+
+  /**
    * Extension methods for [[ScaleFactor]] providing utility functions.
    */
   extension (s: ScaleFactor)

--- a/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
+++ b/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
@@ -93,25 +93,25 @@ object SimulationDefaults:
       val defaultSensors: Vector[Sensor[Robot, Environment]] = Vector.empty
 
       val stdProximitySensors: Vector[Sensor[Robot, Environment]] = Vector(
-        ProximitySensor(Orientation(0.0), radius, 5.0),
-        ProximitySensor(Orientation(45.0), radius, 5.0),
-        ProximitySensor(Orientation(90.0), radius, 5.0),
-        ProximitySensor(Orientation(135.0), radius, 5.0),
-        ProximitySensor(Orientation(180.0), radius, 5.0),
-        ProximitySensor(Orientation(225.0), radius, 5.0),
-        ProximitySensor(Orientation(270.0), radius, 5.0),
-        ProximitySensor(Orientation(315.0), radius, 5.0),
+        ProximitySensor(Orientation(0.0), radius),
+        ProximitySensor(Orientation(45.0), radius),
+        ProximitySensor(Orientation(90.0), radius),
+        ProximitySensor(Orientation(135.0), radius),
+        ProximitySensor(Orientation(180.0), radius),
+        ProximitySensor(Orientation(225.0), radius),
+        ProximitySensor(Orientation(270.0), radius),
+        ProximitySensor(Orientation(315.0), radius),
       )
 
       val stdLightSensors: Vector[Sensor[Robot, Environment]] = Vector(
-        LightSensor(Orientation(0.0), radius, 5.0),
-        LightSensor(Orientation(45.0), radius, 5.0),
-        LightSensor(Orientation(90.0), radius, 5.0),
-        LightSensor(Orientation(135.0), radius, 5.0),
-        LightSensor(Orientation(180.0), radius, 5.0),
-        LightSensor(Orientation(225.0), radius, 5.0),
-        LightSensor(Orientation(270.0), radius, 5.0),
-        LightSensor(Orientation(315.0), radius, 5.0),
+        LightSensor(Orientation(0.0)),
+        LightSensor(Orientation(45.0)),
+        LightSensor(Orientation(90.0)),
+        LightSensor(Orientation(135.0)),
+        LightSensor(Orientation(180.0)),
+        LightSensor(Orientation(225.0)),
+        LightSensor(Orientation(270.0)),
+        LightSensor(Orientation(315.0)),
       )
 
       val defaultBehavior: Rule[IO, SensorReadings, Action[IO]] = Rules.alwaysForward[IO]

--- a/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
+++ b/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
@@ -11,6 +11,7 @@ import io.github.srs.model.entity.dynamicentity.behavior.BehaviorTypes.Rule
 import io.github.srs.model.entity.dynamicentity.behavior.Rules
 import io.github.srs.model.entity.dynamicentity.sensor.{ ProximitySensor, Sensor, SensorReadings }
 import io.github.srs.model.environment.Environment
+import io.github.srs.model.entity.dynamicentity.sensor.LightSensor
 
 object SimulationDefaults:
 
@@ -102,8 +103,16 @@ object SimulationDefaults:
         ProximitySensor(Orientation(315.0), radius, 5.0),
       )
 
-      // TODO: Add light sensors when implemented
-      val stdLightSensors: Vector[Sensor[Robot, Environment]] = Vector.empty
+      val stdLightSensors: Vector[Sensor[Robot, Environment]] = Vector(
+        LightSensor(Orientation(0.0), radius, 5.0),
+        LightSensor(Orientation(45.0), radius, 5.0),
+        LightSensor(Orientation(90.0), radius, 5.0),
+        LightSensor(Orientation(135.0), radius, 5.0),
+        LightSensor(Orientation(180.0), radius, 5.0),
+        LightSensor(Orientation(225.0), radius, 5.0),
+        LightSensor(Orientation(270.0), radius, 5.0),
+        LightSensor(Orientation(315.0), radius, 5.0),
+      )
 
       val defaultBehavior: Rule[IO, SensorReadings, Action[IO]] = Rules.alwaysForward[IO]
     end Robot

--- a/src/test/resources/configuration.yml
+++ b/src/test/resources/configuration.yml
@@ -25,5 +25,5 @@ environment:
         radius: 0.5
         speed: 1.0
         withProximitySensors: true
-        withLightSensors: false
+        withLightSensors: true
         behavior: "randomWalk"

--- a/src/test/scala/io/github/srs/config/YamlConfigManagerTest.scala
+++ b/src/test/scala/io/github/srs/config/YamlConfigManagerTest.scala
@@ -50,7 +50,7 @@ class YamlConfigManagerTest extends AnyFlatSpec with Matchers:
     val lightId = SimulationDefaults.StaticEntity.Light.defaultId
     val robotId = SimulationDefaults.DynamicEntity.Robot.defaultId
     val dwm = differentialWheelMotor withLeftSpeed 2.0 withRightSpeed 3.0
-    val ps = proximitySensor withDistance 0.5 withOffset Orientation(90.0) withRange 1.5
+    val ps = proximitySensor withOffset Orientation(90.0) withRange 1.5
     val orientation = Orientation(0.0)
     val l =
       light withId lightId at (
@@ -59,7 +59,7 @@ class YamlConfigManagerTest extends AnyFlatSpec with Matchers:
       ) withIntensity 0.5 withAttenuation 1.0 withIlluminationRadius 8.0 withOrientation orientation
     val o = obstacle withId obstacleId at (2.0, 2.0) withWidth 1.0 withHeight 1.0 withOrientation orientation
     val r =
-      robot withId robotId at (4.0, 4.0) withOrientation orientation withSpeed 1.0 withShape (Circle(0.5)) containing
+      robot withId robotId at (4.0, 4.0) withOrientation orientation withSpeed 1.0 withShape Circle(0.5) containing
         dwm and ps
 
     val env = environment containing l and o and r
@@ -93,7 +93,6 @@ class YamlConfigManagerTest extends AnyFlatSpec with Matchers:
         |      sensors:
         |      - proximitySensor:
         |          offset: 90.0
-        |          distance: 0.5
         |          range: 1.5
         |      actuators:
         |      - differentialWheelMotor:

--- a/src/test/scala/io/github/srs/config/YamlManagerTest.scala
+++ b/src/test/scala/io/github/srs/config/YamlManagerTest.scala
@@ -177,9 +177,8 @@ class YamlManagerTest extends AnyFlatSpec with Matchers:
                 robot.sensors.headOption match
                   case Some(sensor) =>
                     sensor match
-                      case ProximitySensor(offset, distance, range) =>
+                      case ProximitySensor(offset, range) =>
                         val _ = offset.degrees should be(0.0)
-                        val _ = distance should be(0.5)
                         val _ = range should be > 2.29
                         val _ =
                           range should be < 2.31 // Allowing a small margin of error due to floating point precision
@@ -230,7 +229,7 @@ class YamlManagerTest extends AnyFlatSpec with Matchers:
     val lightId = SimulationDefaults.StaticEntity.Light.defaultId
     val robotId = SimulationDefaults.DynamicEntity.Robot.defaultId
     val dwm = differentialWheelMotor withLeftSpeed 2.0 withRightSpeed 3.0
-    val ps = proximitySensor withDistance 0.5 withOffset Orientation(90.0) withRange 1.5
+    val ps = proximitySensor withOffset Orientation(90.0) withRange 1.5
     val orientation = Orientation(0.0)
     val l =
       light withId lightId at (
@@ -275,7 +274,6 @@ class YamlManagerTest extends AnyFlatSpec with Matchers:
         |      sensors:
         |      - proximitySensor:
         |          offset: 90.0
-        |          distance: 0.5
         |          range: 1.5
         |      actuators:
         |      - differentialWheelMotor:

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/DynamicEntityTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/DynamicEntityTest.scala
@@ -23,12 +23,10 @@ class DynamicEntityTest extends AnyFlatSpec with Matchers:
   val shape: ShapeType.Circle = ShapeType.Circle(0.5)
 
   val sensorOffset: Orientation = Orientation(0.0)
-  val sensorDistance: Double = 0.5
   val sensorRange: Double = 1.0
 
   val sensor: ProximitySensor[DynamicEntity, Environment] = ProximitySensor(
     offset = sensorOffset,
-    distance = sensorDistance,
     range = sensorRange,
   )
 

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
@@ -2,7 +2,9 @@ package io.github.srs.model.entity.dynamicentity
 
 import scala.concurrent.duration.{ FiniteDuration, MILLISECONDS }
 
+import cats.effect.unsafe.implicits.global
 import cats.Id
+import cats.effect.IO
 import io.github.srs.model.entity.*
 import io.github.srs.model.entity.dynamicentity.action.MovementActionFactory.*
 import io.github.srs.model.entity.dynamicentity.action.SequenceAction.thenDo
@@ -152,7 +154,10 @@ class RobotTest extends AnyFlatSpec with Matchers:
     inside((defaultRobot containing proximitySensor).validate):
       case Right(robot) =>
         val environment = Environment(10, 10)
-        val sensedData = robot.senseAll[Id](environment)
-        sensedData should contain only SensorReading(proximitySensor, proximitySensor.sense[Id](robot, environment))
+        val sensedData = robot.senseAll[IO](environment).unsafeRunSync()
+        sensedData should contain only SensorReading(
+          proximitySensor,
+          proximitySensor.sense[IO](robot, environment).unsafeRunSync(),
+        )
 
 end RobotTest

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/RobotTest.scala
@@ -31,7 +31,7 @@ class RobotTest extends AnyFlatSpec with Matchers:
     DifferentialWheelMotor(Wheel(1.0, ShapeType.Circle(0.5)), Wheel(1.0, ShapeType.Circle(0.5)))
 
   val proximitySensor: Sensor[Robot, Environment] =
-    ProximitySensor(Orientation(0.0), 0.5, 3.0)
+    ProximitySensor(Orientation(0.0), 3.0)
 
   val defaultRobot: Robot = robot at initialPosition withShape shape withOrientation initialOrientation
 

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/behavior/PolicyTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/behavior/PolicyTest.scala
@@ -19,7 +19,7 @@ final class PolicyTest extends AnyFlatSpec:
 
   // ---------- helpers -----------------------------------------------------
   private val front =
-    ProximitySensor[Robot, Environment](Orientation(0), 0.1, 1.0)
+    ProximitySensor[Robot, Environment](Orientation(0), 1.0)
   private def r(d: Double) = Vector(SensorReading(front, d))
 
   given CanEqual[Action[Id], Action[Id]] = CanEqual.derived

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/behavior/RulesTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/behavior/RulesTest.scala
@@ -18,7 +18,7 @@ import io.github.srs.model.environment.Environment
 final class RulesTest extends AnyFlatSpec:
 
   private val front =
-    ProximitySensor[Robot, Environment](Orientation(0), 0.1, 1.0)
+    ProximitySensor[Robot, Environment](Orientation(0), 1.0)
 
   private def readings(d: Double): SensorReadings =
     Vector(SensorReading(front, d))

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/behavior/SensorDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/behavior/SensorDslTest.scala
@@ -16,7 +16,7 @@ import org.scalatest.matchers.should.Matchers.*
 final class SensorDslTest extends AnyFlatSpec:
 
   private val front =
-    ProximitySensor[Robot, Environment](Orientation(0), 0.1, 1.0)
+    ProximitySensor[Robot, Environment](Orientation(0), 1.0)
 
   private def readings(d: Double): SensorReadings =
     Vector(SensorReading(front, d))

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDslTest.scala
@@ -27,9 +27,9 @@ class RobotDslTest extends AnyFlatSpec with Matchers:
   val wheelMotor2: DifferentialWheelMotor =
     DifferentialWheelMotor(Wheel(3.0, ShapeType.Circle(wheelRadius)), Wheel(4.0, ShapeType.Circle(wheelRadius)))
 
-  val sensor: Sensor[Robot, Environment] = ProximitySensor(Orientation(0.0), 0.5, 3.0)
+  val sensor: Sensor[Robot, Environment] = ProximitySensor(Orientation(0.0), 3.0)
 
-  val sensor2: Sensor[Robot, Environment] = ProximitySensor(Orientation(90.0), 0.5, 3.0)
+  val sensor2: Sensor[Robot, Environment] = ProximitySensor(Orientation(90.0), 3.0)
 
   "Robot DSL" should "create a robot with default properties" in:
     import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.*

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
@@ -10,7 +10,6 @@ import io.github.srs.model.entity.staticentity.StaticEntity.Light
 import io.github.srs.model.environment.Environment
 import io.github.srs.model.environment.dsl.CreationDSL.*
 import io.github.srs.utils.SimulationDefaults.StaticEntity.Light.{ defaultOrientation, defaultRadius }
-import org.scalatest.Inside.inside
 import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.compatible.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
@@ -21,9 +20,8 @@ class LightSensorTest extends AnyFlatSpec with Matchers:
   given CanEqual[Orientation, Orientation] = CanEqual.derived
 
   val offset: Orientation = Orientation(0.0)
-  val distance: Double = 0.5
   val range: Double = 5.0
-  val sensor: LightSensor[DynamicEntity, Environment] = LightSensor(offset, distance, range)
+  val sensor: LightSensor[DynamicEntity, Environment] = LightSensor(offset)
 
   val pointingDownSensor: LightSensor[DynamicEntity, Environment] = createSensor(270)
   val pointingBackwardSensor: LightSensor[DynamicEntity, Environment] = createSensor(180)
@@ -44,7 +42,7 @@ class LightSensorTest extends AnyFlatSpec with Matchers:
   ).validate.toOption.value
 
   private def createSensor(orientationDegrees: Double): LightSensor[DynamicEntity, Environment] =
-    LightSensor(Orientation(orientationDegrees), 0.5, 5.0)
+    LightSensor(Orientation(orientationDegrees))
 
   private def createLight(
       position: Point2D,
@@ -75,14 +73,7 @@ class LightSensorTest extends AnyFlatSpec with Matchers:
     val environment = createEnvironment(entities + robot)
     sensor.sense[IO](robot, environment).unsafeRunSync()
 
-  "LightSensor" should "have a valid offset, distance, and range" in:
-    inside(LightSensor(offset, distance, range).validate) { case Right(s) =>
-      val _ = s.offset shouldBe offset
-      val _ = s.distance shouldBe distance
-      s.range shouldBe range
-    }
-
-  it should "sense correctly an environment without light" in:
+  "LightSensor" should "sense correctly an environment without light" in:
     val reading = getSensorReading(sensor, Set.empty)
     reading should be(0.0)
 

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
@@ -1,0 +1,125 @@
+package io.github.srs.model.entity.dynamicentity.sensor
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.github.srs.model.entity.*
+import io.github.srs.model.entity.dynamicentity.actuator.Actuator
+import io.github.srs.model.entity.dynamicentity.dsl.RobotDsl.*
+import io.github.srs.model.entity.dynamicentity.{ DynamicEntity, Robot }
+import io.github.srs.model.entity.staticentity.StaticEntity.Light
+import io.github.srs.model.environment.Environment
+import io.github.srs.model.environment.dsl.CreationDSL.*
+import io.github.srs.utils.SimulationDefaults.StaticEntity.Light.{ defaultOrientation, defaultRadius }
+import org.scalatest.Inside.inside
+import org.scalatest.OptionValues.convertOptionToValuable
+import org.scalatest.compatible.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LightSensorTest extends AnyFlatSpec with Matchers:
+
+  given CanEqual[Orientation, Orientation] = CanEqual.derived
+
+  val offset: Orientation = Orientation(0.0)
+  val distance: Double = 0.5
+  val range: Double = 5.0
+  val sensor: LightSensor[DynamicEntity, Environment] = LightSensor(offset, distance, range)
+
+  val pointingDownSensor: LightSensor[DynamicEntity, Environment] = createSensor(270)
+  val pointingBackwardSensor: LightSensor[DynamicEntity, Environment] = createSensor(180)
+  val pointingLeftSensor: LightSensor[DynamicEntity, Environment] = createSensor(90)
+
+  // Diagonal sensors
+  val pointingNorthEastSensor: LightSensor[DynamicEntity, Environment] = createSensor(45)
+  val pointingSouthEastSensor: LightSensor[DynamicEntity, Environment] = createSensor(315)
+  val pointingSouthWestSensor: LightSensor[DynamicEntity, Environment] = createSensor(225)
+  val pointingNorthWestSensor: LightSensor[DynamicEntity, Environment] = createSensor(135)
+
+  val robot: Robot = Robot(
+    position = Point2D(6.0, 6.0),
+    shape = ShapeType.Circle(0.5),
+    orientation = Orientation(0.0),
+    actuators = Seq.empty[Actuator[Robot]],
+    sensors = Vector(sensor, pointingDownSensor, pointingBackwardSensor, pointingLeftSensor),
+  ).validate.toOption.value
+
+  private def createSensor(orientationDegrees: Double): LightSensor[DynamicEntity, Environment] =
+    LightSensor(Orientation(orientationDegrees), 0.5, 5.0)
+
+  private def createLight(
+      position: Point2D,
+      illuminationRadius: Double = 5,
+      intensity: Double = 1,
+      attenuation: Double = 1,
+  ): Light =
+    Light(
+      pos = position,
+      orient = defaultOrientation,
+      radius = defaultRadius,
+      illuminationRadius = illuminationRadius,
+      intensity = intensity,
+      attenuation = attenuation,
+    )
+
+  private def createEnvironment(entities: Set[Entity], width: Int = 20, height: Int = 20): Environment =
+    (environment
+      withWidth width
+      withHeight height
+      containing entities).validate
+      .fold(err => fail(s"Environment invalid in test fixture: $err"), identity)
+
+  private def getSensorReading(
+      sensor: LightSensor[DynamicEntity, Environment],
+      entities: Set[Entity],
+  ): Double =
+    val environment = createEnvironment(entities + robot)
+    sensor.sense[IO](robot, environment).unsafeRunSync()
+
+  "LightSensor" should "have a valid offset, distance, and range" in:
+    inside(LightSensor(offset, distance, range).validate) { case Right(s) =>
+      val _ = s.offset shouldBe offset
+      val _ = s.distance shouldBe distance
+      s.range shouldBe range
+    }
+
+  it should "sense correctly an environment without light" in:
+    val reading = getSensorReading(sensor, Set.empty)
+    reading should be(0.0)
+
+  it should "sense correctly a nearby light" in:
+    import Point2D.*
+    val light = createLight(robot.position + (0.6, 0))
+    val reading = getSensorReading(sensor, Set(light))
+    reading should be > 0.9
+
+  it should "read a lower value for a distant light" in:
+    import Point2D.*
+    val light = createLight(robot.position + (3.0, 0))
+    val reading = getSensorReading(sensor, Set(light))
+    reading should be < 0.6
+
+  it should "read a lower value for a light with lower intensity" in:
+    import Point2D.*
+    val light = createLight(robot.position + (0.6, 0), intensity = 0.5)
+    val reading = getSensorReading(sensor, Set(light))
+    reading should be < 0.9
+
+  it should "read a lower value from the diagonal sensor pointing to a light" in:
+    import Point2D.*
+    val light = createLight(robot.position + (0.6, 0))
+    val reading = getSensorReading(pointingNorthEastSensor, Set(light))
+    reading should be < 0.9
+
+  it should "not see the light from the diagonal sensor pointing away from a light" in:
+    import Point2D.*
+    val light = createLight(robot.position + (0.6, 0))
+    val reading = getSensorReading(pointingSouthWestSensor, Set(light))
+    reading should be(0.0)
+
+  it should "not see the light from the sensor pointing away from a light" in:
+    import Point2D.*
+    val light = createLight(robot.position + (0.6, 0))
+    val reading = getSensorReading(pointingBackwardSensor, Set(light))
+    reading should be(0.0)
+
+end LightSensorTest

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/ProximitySensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/ProximitySensorTest.scala
@@ -23,9 +23,8 @@ import org.scalatest.matchers.should.Matchers
 class ProximitySensorTest extends AnyFlatSpec with Matchers:
 
   val offset: Orientation = Orientation(0.0)
-  val distance: Double = 0.5
   val range: Double = 5.0
-  val sensor: ProximitySensor[DynamicEntity, Environment] = ProximitySensor(offset, distance, range)
+  val sensor: ProximitySensor[DynamicEntity, Environment] = ProximitySensor(offset, range)
 
   val pointingDownSensor: ProximitySensor[DynamicEntity, Environment] = createSensor(270)
   val pointingBackwardSensor: ProximitySensor[DynamicEntity, Environment] = createSensor(180)
@@ -46,7 +45,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
   ).validate.toOption.value
 
   private def createSensor(orientationDegrees: Double): ProximitySensor[DynamicEntity, Environment] =
-    ProximitySensor(Orientation(orientationDegrees), 0.5, 5.0)
+    ProximitySensor(Orientation(orientationDegrees), 5.0)
 
   private def createObstacle(
       id: UUID = UUID.randomUUID(),
@@ -75,19 +74,14 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     sensor.sense[IO](robot, environment).unsafeRunSync()
 
   "ProximitySensor" should "have a valid offset, distance, and range" in:
-    inside(ProximitySensor(offset, distance, range).validate):
+    inside(ProximitySensor(offset, range).validate):
       case Right(sensor) =>
-        (sensor.offset, sensor.distance, sensor.range) should be(
-          (offset, distance, range),
+        (sensor.offset, sensor.range) should be(
+          (offset, range),
         )
 
-  it should "not be able to create a sensor with negative distance" in:
-    inside(ProximitySensor(offset, -1.0, range).validate):
-      case Left(error: DomainError) =>
-        error shouldBe a[DomainError.NegativeOrZero]
-
   it should "not be able to create a sensor with negative range" in:
-    inside(ProximitySensor(offset, distance, -1.0).validate):
+    inside(ProximitySensor(offset, -1.0).validate):
       case Left(error: DomainError) =>
         error shouldBe a[DomainError.NegativeOrZero]
 

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/ProximitySensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/ProximitySensorTest.scala
@@ -4,7 +4,8 @@ import java.util.UUID
 
 import scala.language.postfixOps
 
-import cats.Id
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import io.github.srs.model.entity.*
 import io.github.srs.model.entity.dynamicentity.actuator.Actuator
 import io.github.srs.model.entity.dynamicentity.dsl.RobotDsl.*
@@ -71,7 +72,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
       entities: Set[Entity],
   ): Double =
     val environment = createEnvironment(entities + robot)
-    sensor.sense[Id](robot, environment)
+    sensor.sense[IO](robot, environment).unsafeRunSync()
 
   "ProximitySensor" should "have a valid offset, distance, and range" in:
     inside(ProximitySensor(offset, distance, range).validate):
@@ -108,7 +109,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
   it should "sense an obstacle that is very narrow" in:
     val obstacle = createObstacle(position = Point2D(7.5, 6.0), width = 0.01)
     val environment = createEnvironment(Set(robot, obstacle))
-    val sensorReading = sensor.sense[Id](robot, environment)
+    val sensorReading = sensor.sense[IO](robot, environment).unsafeRunSync()
     sensorReading should be < 1.0 // Should detect the narrow obstacle
 
   it should "not sense an obstacle positioned slightly to the side" in:
@@ -251,7 +252,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val obstacleNE =
       createObstacle(position = Point2D(7.0, 5.25), height = 0.5) // Positioned along NE diagonal from sensor
     val environment = createEnvironment(Set(robot, obstacleNE))
-    val sensorReading = pointingNorthEastSensor.sense[Id](robot, environment)
+    val sensorReading = pointingNorthEastSensor.sense[IO](robot, environment).unsafeRunSync()
     sensorReading should be < 0.05 // Should detect obstacle very close
 
   it should "not sense an obstacle outside northeast sensor range" in:
@@ -263,7 +264,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val obstacleSE =
       createObstacle(position = Point2D(7.0, 6.75), height = 0.5) // Positioned along SE diagonal from sensor
     val environment = createEnvironment(Set(robot, obstacleSE))
-    val sensorReading = pointingSouthEastSensor.sense[Id](robot, environment)
+    val sensorReading = pointingSouthEastSensor.sense[IO](robot, environment).unsafeRunSync()
     sensorReading should be < 0.05 // Should detect obstacle (return value less than 1.0)
 
   it should "not sense an obstacle outside southeast sensor range" in:
@@ -278,7 +279,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithObstacle = createEnvironment(Set(rotatedRobot, obstacleNorth))
 
     // Forward sensor (offset 0) should now point north due to 90-degree rotation
-    val forwardSensorReading = sensor.sense[Id](rotatedRobot, envWithObstacle)
+    val forwardSensorReading = sensor.sense[IO](rotatedRobot, envWithObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.01 // Should detect obstacle to the north
 
   it should "sense correctly when robot is rotated 180 degrees" in:
@@ -287,7 +288,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithObstacles = createEnvironment(Set(rotatedRobot, obstacleInFront))
 
     // Forward sensor should now point backward due to 180-degree rotation
-    val forwardSensorReading = sensor.sense[Id](rotatedRobot, envWithObstacles)
+    val forwardSensorReading = sensor.sense[IO](rotatedRobot, envWithObstacles).unsafeRunSync()
     forwardSensorReading should be < 0.01 // Should detect obstacle that's now "in front"
 
   it should "sense correctly when robot is rotated 270 degrees" in:
@@ -296,7 +297,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithObstacle = createEnvironment(Set(rotatedRobot, obstacleSouth))
 
     // Forward sensor should now point south due to 270-degree rotation
-    val forwardSensorReading = sensor.sense[Id](rotatedRobot, envWithObstacle)
+    val forwardSensorReading = sensor.sense[IO](rotatedRobot, envWithObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.01 // Should detect obstacle to the south
 
   it should "sense correctly when obstacle is rotated 90 degrees" in:
@@ -306,7 +307,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
 
     // If the obstacle is vertical, the forward sensor should detect it
     // since it is now aligned with the robot's forward direction
-    val forwardSensorReading = sensor.sense[Id](robot, envWithRotatedObstacle)
+    val forwardSensorReading = sensor.sense[IO](robot, envWithRotatedObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.01 // Should detect the rotated obstacle
 
   it should "sense correctly when obstacle is rotated 180 degrees" in:
@@ -315,7 +316,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithRotatedObstacle = createEnvironment(Set(robot, rotatedObstacle))
 
     // Forward sensor should still detect the obstacle
-    val forwardSensorReading = sensor.sense[Id](robot, envWithRotatedObstacle)
+    val forwardSensorReading = sensor.sense[IO](robot, envWithRotatedObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.01 // Should detect the rotated obstacle
 
   it should "sense correctly when obstacle is rotated 270 degrees" in:
@@ -324,7 +325,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithRotatedObstacle = createEnvironment(Set(robot, rotatedObstacle))
 
     // Forward sensor should now point south due to 270-degree rotation
-    val forwardSensorReading = sensor.sense[Id](robot, envWithRotatedObstacle)
+    val forwardSensorReading = sensor.sense[IO](robot, envWithRotatedObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.01 // Should detect the rotated obstacle
 
   it should "sense an obstacle rotated by 45 degrees" in:
@@ -333,7 +334,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithRotatedObstacle = createEnvironment(Set(robot, rotatedObstacle))
 
     // Forward sensor should now point northeast due to 45-degree rotation
-    val forwardSensorReading = pointingNorthEastSensor.sense[Id](robot, envWithRotatedObstacle)
+    val forwardSensorReading = pointingNorthEastSensor.sense[IO](robot, envWithRotatedObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.1 // Should detect obstacle in the northeast direction
 
   it should "sense an obstacle rotated by 45 degrees at the edge of its range" in:
@@ -353,7 +354,7 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val envWithObstacle = createEnvironment(Set(rotatedRobot, obstacleDiagonal))
 
     // Forward sensor should now point northeast due to 45-degree rotation
-    val forwardSensorReading = sensor.sense[Id](rotatedRobot, envWithObstacle)
+    val forwardSensorReading = sensor.sense[IO](rotatedRobot, envWithObstacle).unsafeRunSync()
     forwardSensorReading should be < 0.05 // Should detect obstacle in the northeast direction
 
   it should "handle multiple obstacles at different angles with rotated robot" in:
@@ -375,10 +376,10 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
 
     // With 90-degree rotation: forward points north, backward points south,
     // left points west, down points east
-    val forwardReading = sensor.sense[Id](rotatedRobot, envWithObstacles)
-    val backwardReading = pointingBackwardSensor.sense[Id](rotatedRobot, envWithObstacles)
-    val leftReading = pointingLeftSensor.sense[Id](rotatedRobot, envWithObstacles)
-    val downReading = pointingDownSensor.sense[Id](rotatedRobot, envWithObstacles)
+    val forwardReading = sensor.sense[IO](rotatedRobot, envWithObstacles).unsafeRunSync()
+    val backwardReading = pointingBackwardSensor.sense[IO](rotatedRobot, envWithObstacles).unsafeRunSync()
+    val leftReading = pointingLeftSensor.sense[IO](rotatedRobot, envWithObstacles).unsafeRunSync()
+    val downReading = pointingDownSensor.sense[IO](rotatedRobot, envWithObstacles).unsafeRunSync()
 
     // All sensors should detect obstacles
     Seq(forwardReading, backwardReading, leftReading, downReading).forall(_ < 0.01) should be(true)
@@ -409,17 +410,17 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
   it should "handle obstacles with extreme aspect ratios" in:
     val tallThinObstacle = createObstacle(position = Point2D(7.5, 6.0), width = 0.001, height = 10.0)
     val environment = createEnvironment(Set(robot, tallThinObstacle))
-    val sensorReading = sensor.sense[Id](robot, environment)
+    val sensorReading = sensor.sense[IO](robot, environment).unsafeRunSync()
     sensorReading should be < 1.0 // Should detect very thin obstacle
 
   it should "sense environment boundaries correctly" in:
     val robot = createRobot(Point2D(1, 1), Orientation(0.0))
     val environment = createEnvironment(Set(robot), width = 2, height = 2)
     val sensorReadings = Seq(
-      sensor.sense[Id](robot, environment),
-      pointingDownSensor.sense[Id](robot, environment),
-      pointingBackwardSensor.sense[Id](robot, environment),
-      pointingLeftSensor.sense[Id](robot, environment),
+      sensor.sense[IO](robot, environment).unsafeRunSync(),
+      pointingDownSensor.sense[IO](robot, environment).unsafeRunSync(),
+      pointingBackwardSensor.sense[IO](robot, environment).unsafeRunSync(),
+      pointingLeftSensor.sense[IO](robot, environment).unsafeRunSync(),
     )
     sensorReadings.forall(_ == 0.1) should be(true) // Should detect boundaries
 
@@ -427,10 +428,10 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val rotatedRobot = createRobot(Point2D(1, 1), Orientation(90))
     val environment = createEnvironment(Set(rotatedRobot), width = 2, height = 2)
     val sensorReadings = Seq(
-      sensor.sense[Id](rotatedRobot, environment),
-      pointingDownSensor.sense[Id](rotatedRobot, environment),
-      pointingBackwardSensor.sense[Id](rotatedRobot, environment),
-      pointingLeftSensor.sense[Id](rotatedRobot, environment),
+      sensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
+      pointingDownSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
+      pointingBackwardSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
+      pointingLeftSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
     )
     sensorReadings.forall(_ == 0.1) should be(true) // Should detect boundaries
 
@@ -438,10 +439,10 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val rotatedRobot = createRobot(Point2D(1, 1), Orientation(45))
     val environment = createEnvironment(Set(rotatedRobot), width = 2, height = 2)
     val sensorReadings = Seq(
-      pointingNorthEastSensor.sense[Id](rotatedRobot, environment),
-      pointingSouthEastSensor.sense[Id](rotatedRobot, environment),
-      pointingSouthWestSensor.sense[Id](rotatedRobot, environment),
-      pointingNorthWestSensor.sense[Id](rotatedRobot, environment),
+      pointingNorthEastSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
+      pointingSouthEastSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
+      pointingSouthWestSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
+      pointingNorthWestSensor.sense[IO](rotatedRobot, environment).unsafeRunSync(),
     )
     sensorReadings.forall(_ == 0.1) should be(true) // Should detect boundaries
 
@@ -449,12 +450,12 @@ class ProximitySensorTest extends AnyFlatSpec with Matchers:
     val edgeRobot = createRobot(Point2D(5.6, 5.6), Orientation(0.0))
     val environment = createEnvironment(Set(edgeRobot), width = 11, height = 11)
     val closeEnoughSensors = Seq(
-      sensor.sense[Id](edgeRobot, environment),
-      pointingDownSensor.sense[Id](edgeRobot, environment),
+      sensor.sense[IO](edgeRobot, environment).unsafeRunSync(),
+      pointingDownSensor.sense[IO](edgeRobot, environment).unsafeRunSync(),
     )
     val notCloseEnoughSensors = Seq(
-      pointingBackwardSensor.sense[Id](edgeRobot, environment),
-      pointingLeftSensor.sense[Id](edgeRobot, environment),
+      pointingBackwardSensor.sense[IO](edgeRobot, environment).unsafeRunSync(),
+      pointingLeftSensor.sense[IO](edgeRobot, environment).unsafeRunSync(),
     )
     val _ =
       closeEnoughSensors.forall(reading => reading > 0.9 && reading < 1) should be(true) // Should detect boundaries

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/SensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/SensorTest.scala
@@ -2,9 +2,10 @@ package io.github.srs.model.entity.dynamicentity.sensor
 
 import java.util.UUID
 
-import cats.effect.unsafe.implicits.global
 import cats.Monad
 import cats.effect.IO
+import cats.effect.kernel.Sync
+import cats.effect.unsafe.implicits.global
 import io.github.srs.model.entity.dynamicentity.DynamicEntity
 import io.github.srs.model.entity.dynamicentity.action.Action
 import io.github.srs.model.entity.dynamicentity.actuator.Actuator
@@ -16,7 +17,6 @@ import io.github.srs.model.environment.dsl.CreationDSL.*
 import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import cats.effect.kernel.Sync
 
 class SensorTest extends AnyFlatSpec with should.Matchers:
   given CanEqual[Sensor[?, ?], Sensor[?, ?]] = CanEqual.derived
@@ -26,7 +26,6 @@ class SensorTest extends AnyFlatSpec with should.Matchers:
   val shape: ShapeType.Circle = ShapeType.Circle(0.5)
 
   val offset: Orientation = Orientation(0.0)
-  val distance: Distance = 1.0
   val range: Range = 10.0
 
   class Dummy(
@@ -40,19 +39,18 @@ class SensorTest extends AnyFlatSpec with should.Matchers:
   ) extends DynamicEntity:
     def act[F[_]: Monad](): F[Dummy] = Monad[F].pure(this)
 
-  class DummySensor(override val offset: Orientation, override val distance: Distance, override val range: Range)
-      extends Sensor[Dummy, Environment]:
+  class DummySensor(override val offset: Orientation) extends Sensor[Dummy, Environment]:
     override type Data = Double
 
     override def sense[F[_]: Sync](entity: Dummy, env: Environment): F[Double] =
       Sync[F].pure(42.0) // Dummy implementation for sensing
 
-  "Sensor" should "have an offset orientation, distance, and range" in:
-    val sensor = new DummySensor(offset, distance, range)
-    (sensor.offset, sensor.distance, sensor.range) should be((offset, distance, range))
+  "Sensor" should "have an offset orientation" in:
+    val sensor = new DummySensor(offset)
+    sensor.offset should be(offset)
 
   it should "sense the environment and return data" in:
-    val sensor = new DummySensor(offset, distance, range)
+    val sensor = new DummySensor(offset)
     val entity = new Dummy(
       position = initialPosition,
       shape = shape,


### PR DESCRIPTION
This pull request introduces support for light sensors in the robot simulation, refactors sensor effect handling to use `cats.effect.Sync` for all sensing operations, and adds comprehensive tests for the new light sensor functionality. Robots can now be equipped with light sensors, which measure light intensity in the environment, and both proximity and light sensors are now handled in an effectful context (`IO`). The changes also update configuration and simulation defaults to enable light sensors by default.