### PR TITLE
perf: add illumination caching inside environment

### DIFF
--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/sensor/Sensor.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/sensor/Sensor.scala
@@ -8,8 +8,6 @@ import io.github.srs.model.environment.Environment
 import io.github.srs.model.validation.Validation
 import io.github.srs.utils.Ray.intersectRay
 import io.github.srs.utils.SimulationDefaults.DynamicEntity.Sensor.ProximitySensor as ProximitySensorDefaults
-import io.github.srs.model.illumination.LightMap
-import io.github.srs.model.illumination.engine.SquidLibFovEngine
 import io.github.srs.model.illumination.model.ScaleFactor
 import cats.effect.kernel.Sync
 import io.github.srs.model.entity.ShapeType
@@ -154,11 +152,9 @@ final case class LightSensor[Entity <: DynamicEntity, Env <: Environment](
    *   a monadic effect containing the light intensity sensed by the sensor.
    */
   override def sense[F[_]: Sync](entity: Entity, env: Env): F[Data] =
-    val o = origin(entity)
-    for
-      lightMap <- LightMap.cached[F](SquidLibFovEngine, ScaleFactor.default)
-      field <- lightMap.computeField(env = env, includeDynamic = true)
-    yield field.sampleAtWorld(o)(using ScaleFactor.default)
+    Sync[F].pure:
+      val o = origin(entity)
+      env.lightField.sampleAtWorld(o)(using ScaleFactor.default)
 
 end LightSensor
 

--- a/src/main/scala/io/github/srs/model/environment/Environment.scala
+++ b/src/main/scala/io/github/srs/model/environment/Environment.scala
@@ -3,6 +3,9 @@ package io.github.srs.model.environment
 import io.github.srs.model.entity.Entity
 import io.github.srs.model.entity.dynamicentity.Robot
 import io.github.srs.utils.SimulationDefaults.Environment.*
+import io.github.srs.model.illumination.model.LightField
+import io.github.srs.utils.SimulationDefaults
+import cats.effect.unsafe.implicits.global
 
 /**
  * Represents the environment in which entities exist.
@@ -17,7 +20,7 @@ trait EnvironmentParameters:
    * @return
    *   a Double representing the width of the environment.
    */
-  val width: Int
+  def width: Int
 
   /**
    * The height of the environment.
@@ -25,7 +28,7 @@ trait EnvironmentParameters:
    * @return
    *   a Double representing the height of the environment.
    */
-  val height: Int
+  def height: Int
 
   /**
    * A set of entities that exist within the environment.
@@ -33,7 +36,15 @@ trait EnvironmentParameters:
    * @return
    *   a Set of [[Entity]] representing the entities in the environment.
    */
-  val entities: Set[Entity]
+  def entities: Set[Entity]
+
+  /**
+   * The light field of the environment, representing the illumination conditions.
+   *
+   * @return
+   *   a [[LightField]] representing the light field of the environment.
+   */
+  def lightField: LightField
 
 end EnvironmentParameters
 
@@ -44,7 +55,10 @@ final case class Environment(
     override val width: Int = defaultWidth,
     override val height: Int = defaultHeight,
     override val entities: Set[Entity] = defaultEntities,
-) extends EnvironmentParameters
+) extends EnvironmentParameters:
+
+  lazy val lightField: LightField =
+    SimulationDefaults.lightMap.computeField(this, includeDynamic = true).unsafeRunSync()
 
 object ValidEnvironment:
   opaque type ValidEnvironment = Environment

--- a/src/main/scala/io/github/srs/model/illumination/model/ScaleFactor.scala
+++ b/src/main/scala/io/github/srs/model/illumination/model/ScaleFactor.scala
@@ -31,7 +31,7 @@ object ScaleFactor:
    * @return
    *   The default scale factor as an [[ScaleFactor]].
    */
-  def default: ScaleFactor = 100
+  def default: ScaleFactor = 10
 
   /**
    * Extension methods for [[ScaleFactor]] providing utility functions.

--- a/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
+++ b/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
@@ -5,12 +5,17 @@ import java.util.UUID
 
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
+import cats.effect.unsafe.implicits.global
 import io.github.srs.model.entity.*
 import io.github.srs.model.entity.dynamicentity.Robot
 import io.github.srs.model.entity.dynamicentity.actuator.{ Actuator, Wheel as ActWheel }
 import io.github.srs.model.entity.dynamicentity.behavior.Policy
 import io.github.srs.model.entity.dynamicentity.sensor.*
 import io.github.srs.model.environment.Environment
+import cats.effect.IO
+import io.github.srs.model.illumination.LightMap
+import io.github.srs.model.illumination.engine.SquidLibFovEngine
+import io.github.srs.model.illumination.model.ScaleFactor
 
 object SimulationDefaults:
 
@@ -79,6 +84,7 @@ object SimulationDefaults:
   val seed: Option[Long] = None
   val debugMode = true
   val binarySearchDurationThreshold: FiniteDuration = 1.microseconds
+  val lightMap: LightMap[IO] = LightMap.create[IO](SquidLibFovEngine, ScaleFactor.default).unsafeRunSync()
 
   object SimulationConfig:
     val maxCount = 10_000
@@ -140,7 +146,6 @@ object SimulationDefaults:
 
       object ProximitySensor:
         val defaultOffset: Double = 0.0
-        val defaultDistance: Double = 0.5
         val defaultRange: Double = 5.0
 
     object Robot:

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
@@ -81,7 +81,7 @@ class LightSensorTest extends AnyFlatSpec with Matchers:
     import Point2D.*
     val light = createLight(robot.position + (0.6, 0))
     val reading = getSensorReading(sensor, Set(light))
-    reading should be > 0.9
+    reading should be > 0.95
 
   it should "read a lower value for a distant light" in:
     import Point2D.*
@@ -99,7 +99,7 @@ class LightSensorTest extends AnyFlatSpec with Matchers:
     import Point2D.*
     val light = createLight(robot.position + (0.6, 0))
     val reading = getSensorReading(pointingNorthEastSensor, Set(light))
-    reading should be < 0.9
+    reading should be < 0.95
 
   it should "not see the light from the diagonal sensor pointing away from a light" in:
     import Point2D.*


### PR DESCRIPTION
This pull request refactors how light sensing is handled in the simulation environment, simplifying the process by integrating the light field directly into the `Environment` object and updating related interfaces and defaults. It also adjusts the scale factor for illumination calculations and updates test expectations to match the new behavior.