### PR TITLE
feat(validation): validate robots during environment validation

### DIFF
--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDsl.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDsl.scala
@@ -27,6 +27,15 @@ import io.github.srs.model.entity.dynamicentity.behavior.Policy
  */
 object RobotDsl:
 
+  /**
+   * Validates a Robot entity to ensure it meets the domain constraints.
+   * @param r
+   *   the Robot entity to validate.
+   * @return
+   *   [[Right]] if the robot is valid, or [[Left]] with a validation
+   */
+  def validateRobot(r: Robot): Validation[Robot] = r.validate
+
   /** Creates a new Robot with default properties. */
   def robot: Robot = Robot()
 


### PR DESCRIPTION
This pull request introduces a validation step for `Robot` entities when creating and validating an environment. The main improvement is ensuring that all robots in the environment meet their domain constraints, leading to more robust environment validation logic.