### PR TITLE
refactor: simulation view closing and elapsed time

### DIFF
--- a/src/main/scala/io/github/srs/Main.scala
+++ b/src/main/scala/io/github/srs/Main.scala
@@ -13,7 +13,7 @@ import cats.effect.unsafe.implicits.global
 
       val runner = for
         cfg <- configurationView.init()
-        state = mkInitialState(cfg)
+        state = mkInitialState(cfg, parsed.headless)
         _ <- configurationView.close()
         _ <- launcher.runMVC(state)
       yield ()

--- a/src/main/scala/io/github/srs/model/SimulationConfig.scala
+++ b/src/main/scala/io/github/srs/model/SimulationConfig.scala
@@ -8,6 +8,7 @@ object SimulationConfig:
     case RUNNING
     case PAUSED
     case STOPPED
+    case ELAPSED_TIME
 
   enum SimulationSpeed derives CanEqual:
     case SLOW

--- a/src/main/scala/io/github/srs/model/logic/TimeLogic.scala
+++ b/src/main/scala/io/github/srs/model/logic/TimeLogic.scala
@@ -2,9 +2,9 @@ package io.github.srs.model.logic
 
 import scala.concurrent.duration.FiniteDuration
 
-import io.github.srs.model.SimulationConfig.SimulationSpeed
-import io.github.srs.model.{ ModelModule, SimulationState }
 import cats.effect.IO
+import io.github.srs.model.SimulationConfig.{ SimulationSpeed, SimulationStatus }
+import io.github.srs.model.{ ModelModule, SimulationState }
 
 /**
  * Logic for handling simulation time updates.
@@ -43,9 +43,15 @@ object TimeLogic:
 
   given TickLogic[SimulationState] with
 
-    def tick(s: SimulationState, delta: FiniteDuration): IO[SimulationState] =
+    def tick(s: SimulationState, delta: FiniteDuration): IO[SimulationState] = IO.pure:
       val updatedElapsed = s.elapsedTime + delta
-      IO.pure(s.copy(elapsedTime = updatedElapsed))
 
-    def tickSpeed(s: SimulationState, speed: SimulationSpeed): IO[SimulationState] =
-      IO.pure(s.copy(simulationSpeed = speed))
+      val isElapsedTimeReached: Boolean = s.simulationTime.exists(max => s.elapsedTime >= max)
+
+      s.copy(
+        elapsedTime = updatedElapsed,
+        simulationStatus = if isElapsedTimeReached then SimulationStatus.ELAPSED_TIME else s.simulationStatus,
+      )
+
+    def tickSpeed(s: SimulationState, speed: SimulationSpeed): IO[SimulationState] = IO.pure:
+      s.copy(simulationSpeed = speed)

--- a/src/main/scala/io/github/srs/utils/time/TimeUtils.scala
+++ b/src/main/scala/io/github/srs/utils/time/TimeUtils.scala
@@ -5,17 +5,18 @@ import scala.concurrent.duration.FiniteDuration
 object TimeUtils:
 
   /**
-   * Formats a given duration into a string representation in the format "MM:SS:SSS", where MM are minutes, SS are
-   * seconds, and SSS are milliseconds.
+   * Formats a given duration into a string representation in the format "HH:MM:SS:SSS", where HH are hours, MM are
+   * minutes, SS are seconds, and SSS are milliseconds.
    *
    * @param duration
    *   the duration to format.
    * @return
-   *   a string representing the duration in "MM:SS:SSS" format.
+   *   a string representing the duration in "HH:MM:SS:SSS" format.
    */
   def formatTime(duration: FiniteDuration): String =
     val totalMillis = duration.toMillis
+    val hours = (totalMillis / 3600000) % 24
     val minutes = (totalMillis / 60000) % 60
     val seconds = (totalMillis / 1000) % 60
     val millis = totalMillis % 1000
-    f"$minutes%02d:$seconds%02d:$millis%03d"
+    f"$hours%02d:$minutes%02d:$seconds%02d:$millis%03d"

--- a/src/main/scala/io/github/srs/view/CLIComponent.scala
+++ b/src/main/scala/io/github/srs/view/CLIComponent.scala
@@ -50,7 +50,7 @@ trait CLIComponent[S <: ModelModule.State] extends Component[S]:
      * @inheritdoc
      */
     override def timeElapsed(state: S): IO[Unit] =
-      for _ <- IO.println(s"Simulation finished. Resulting state:\n${prettyPrint(state.environment)}")
+      for _ <- IO.println(s"Simulation finished. Resulting environment:\n${prettyPrint(state.environment)}")
       yield ()
   end CLIViewImpl
 end CLIComponent

--- a/src/main/scala/io/github/srs/view/CLIComponent.scala
+++ b/src/main/scala/io/github/srs/view/CLIComponent.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.std.Queue
 import io.github.srs.controller.protocol.Event
 import io.github.srs.model.ModelModule
+import io.github.srs.model.dsl.EnvironmentToGridDSL.prettyPrint
 import io.github.srs.view.ViewModule.{ Component, Requirements, View }
 
 /**
@@ -42,7 +43,14 @@ trait CLIComponent[S <: ModelModule.State] extends Component[S]:
      * @inheritdoc
      */
     override def close(): IO[Unit] =
-      for _ <- IO.println("Exiting the Scala Robotics Simulator CLI. Goodbye!")
+      for _ <- IO.println("Exiting the Scala Robotics Simulator CLI.")
+      yield ()
+
+    /**
+     * @inheritdoc
+     */
+    override def timeElapsed(state: S): IO[Unit] =
+      for _ <- IO.println(s"Simulation finished. Resulting state:\n${prettyPrint(state.environment)}")
       yield ()
   end CLIViewImpl
 end CLIComponent

--- a/src/main/scala/io/github/srs/view/GUIComponent.scala
+++ b/src/main/scala/io/github/srs/view/GUIComponent.scala
@@ -77,6 +77,13 @@ trait GUIComponent[S <: ModelModule.State] extends Component[S]:
     override def close(): IO[Unit] = IO(frame.dispose())
 
     /**
+     * @inheritdoc
+     */
+    override def timeElapsed(state: S): IO[Unit] = IO:
+      controls.startStopButton.setEnabled(false)
+      controls.pauseResumeButton.setEnabled(false)
+
+    /**
      * Sets up the main UI layout with split pane configuration.
      */
     private def setupUI(): Unit =

--- a/src/main/scala/io/github/srs/view/ViewModule.scala
+++ b/src/main/scala/io/github/srs/view/ViewModule.scala
@@ -43,6 +43,15 @@ object ViewModule:
      */
     def close(): IO[Unit]
 
+    /**
+     * Handles the event when a certain amount of time has elapsed in the simulation.
+     * @param state
+     *   the resulting state after time has elapsed.
+     * @return
+     *   an [[IO]] task that completes when the time elapsed event is handled.
+     */
+    def timeElapsed(state: S): IO[Unit]
+
   end View
 
   /**

--- a/src/main/scala/io/github/srs/view/components/simulation/TimePanel.scala
+++ b/src/main/scala/io/github/srs/view/components/simulation/TimePanel.scala
@@ -69,7 +69,7 @@ class TimePanel extends JPanel:
         case Some(maxTime) =>
           val remaining = maxTime - elapsed
           if remaining.toMillis > 0 then remainingValue.setText(formatTime(remaining))
-          else remainingValue.setText("00:00:00")
+          else remainingValue.setText("00:00:00:00")
         case None =>
           remainingValue.setText("∞")
     }
@@ -79,8 +79,8 @@ class TimePanel extends JPanel:
    */
   def reset(): Unit =
     SwingUtilities.invokeLater { () =>
-      elapsedValue.setText("00:00:00")
-      remainingValue.setText("--:--:--")
+      elapsedValue.setText("00:00:00:00")
+      remainingValue.setText("--:--:--:--")
     }
 
 end TimePanel


### PR DESCRIPTION
This pull request introduces improvements to simulation time handling and status reporting in the Scala Robotics Simulator. The main changes include the addition of a new `ELAPSED_TIME` simulation status, refactoring how simulation stop conditions are handled, and updating time formatting and display across both CLI and GUI interfaces. These updates provide clearer feedback when simulations end due to elapsed time, and unify how simulation completion is managed in both launchers.