### PR TITLE
chore: rename all constants to follow pascal case

### DIFF
--- a/src/main/scala/io/github/srs/config/yaml/parser/YamlSimulationConfigParser.scala
+++ b/src/main/scala/io/github/srs/config/yaml/parser/YamlSimulationConfigParser.scala
@@ -42,8 +42,8 @@ object YamlSimulationConfigParser:
         case Left(err) => Left[Seq[ConfigError], Map[String, Any]](Seq(ConfigError.ParsingError(err.getMessage)))
         case Right(map) => Right[Seq[ConfigError], Map[String, Any]](map)
 
-      simMap <- root.getOptionalSubMap(SimulationFields.self)
-      envMap <- root.getOptionalSubMap(EnvironmentFields.self)
+      simMap <- root.getOptionalSubMap(SimulationFields.Self)
+      envMap <- root.getOptionalSubMap(EnvironmentFields.Self)
 
       sim <- parseSimulation(simMap)
       env <- parseEnvironment(envMap)
@@ -61,8 +61,8 @@ object YamlSimulationConfigParser:
       case None => Right[Seq[ConfigError], Simulation](Simulation.simulation)
       case Some(m) =>
         for
-          duration <- getOptional[Long](SimulationFields.duration, m)
-          seed <- getOptional[Long](SimulationFields.seed, m)
+          duration <- getOptional[Long](SimulationFields.Duration, m)
+          seed <- getOptional[Long](SimulationFields.Seed, m)
         yield Simulation.simulation
           |> (sim => duration.fold(sim)(sim.withDuration))
           |> (sim => seed.fold(sim)(sim.withSeed))
@@ -79,9 +79,9 @@ object YamlSimulationConfigParser:
       case None => Right[Seq[ConfigError], Environment](environment)
       case Some(m) =>
         for
-          width <- getOptional[Int](EnvironmentFields.width, m)
-          height <- getOptional[Int](EnvironmentFields.height, m)
-          entities <- m.parseSequence(EnvironmentFields.entities, parseEntity)
+          width <- getOptional[Int](EnvironmentFields.Width, m)
+          height <- getOptional[Int](EnvironmentFields.Height, m)
+          entities <- m.parseSequence(EnvironmentFields.Entities, parseEntity)
         yield Environment()
           |> (env => width.fold(env)(env.withWidth))
           |> (env => height.fold(env)(env.withHeight))
@@ -99,9 +99,9 @@ object YamlSimulationConfigParser:
    */
   private def parseEntity(map: Map[String, Any]): ConfigResult[Entity] =
     map.headOption match
-      case Some((ObstacleFields.self, v: Map[String, Any] @unchecked)) => parseObstacle(v)
-      case Some((LightFields.self, v: Map[String, Any] @unchecked)) => parseLight(v)
-      case Some((RobotFields.self, v: Map[String, Any] @unchecked)) => YamlSimulationConfigParser.parseRobot(v)
+      case Some((ObstacleFields.Self, v: Map[String, Any] @unchecked)) => parseObstacle(v)
+      case Some((LightFields.Self, v: Map[String, Any] @unchecked)) => parseLight(v)
+      case Some((RobotFields.Self, v: Map[String, Any] @unchecked)) => YamlSimulationConfigParser.parseRobot(v)
       case Some((key, _)) => Left[Seq[ConfigError], Entity](Seq(ConfigError.ParsingError(s"Unknown entity type: $key")))
       case None => Left[Seq[ConfigError], Entity](Seq(ConfigError.ParsingError("Empty entity map")))
 
@@ -122,15 +122,15 @@ object YamlSimulationConfigParser:
    */
   private def parseRobot(map: Map[String, Any]): ConfigResult[Entity] =
     for
-      id <- getOptional[UUID](EntityFields.id, map)
-      pos <- get[List[Double]](EntityFields.position, map)
+      id <- getOptional[UUID](EntityFields.Id, map)
+      pos <- get[List[Double]](EntityFields.Position, map)
       position <- parsePosition(pos)
-      orient <- getOptional[Double](EntityFields.orientation, map)
-      radius <- getOptional[Double](RobotFields.radius, map)
-      speed <- getOptional[Double](RobotFields.speed, map)
-      prox <- getOptional[Boolean](RobotFields.withProximitySensors, map)
-      light <- getOptional[Boolean](RobotFields.withLightSensors, map)
-      behavior <- getOptional[Policy](RobotFields.behavior, map)
+      orient <- getOptional[Double](EntityFields.Orientation, map)
+      radius <- getOptional[Double](RobotFields.Radius, map)
+      speed <- getOptional[Double](RobotFields.Speed, map)
+      prox <- getOptional[Boolean](RobotFields.WithProximitySensors, map)
+      light <- getOptional[Boolean](RobotFields.WithLightSensors, map)
+      behavior <- getOptional[Policy](RobotFields.Behavior, map)
     yield Robot().at(position)
       |> (r => id.fold(r)(r.withId))
       |> (r => orient.fold(r)(o => r.withOrientation(Orientation(o))))
@@ -149,12 +149,12 @@ object YamlSimulationConfigParser:
    */
   private def parseObstacle(map: Map[String, Any]): ConfigResult[Entity] =
     for
-      id <- getOptional[UUID](EntityFields.id, map)
-      pos <- get[List[Double]](EntityFields.position, map)
+      id <- getOptional[UUID](EntityFields.Id, map)
+      pos <- get[List[Double]](EntityFields.Position, map)
       position <- parsePosition(pos)
-      orientation <- getOptional[Double](EntityFields.orientation, map)
-      width <- getOptional[Double](ObstacleFields.width, map)
-      height <- getOptional[Double](ObstacleFields.height, map)
+      orientation <- getOptional[Double](EntityFields.Orientation, map)
+      width <- getOptional[Double](ObstacleFields.Width, map)
+      height <- getOptional[Double](ObstacleFields.Height, map)
     yield obstacle.at(position)
       |> (obs => id.fold(obs)(obs.withId))
       |> (obs => orientation.fold(obs)(o => obs.withOrientation(Orientation(o))))
@@ -170,14 +170,14 @@ object YamlSimulationConfigParser:
    */
   private def parseLight(map: Map[String, Any]): ConfigResult[Entity] =
     for
-      id <- getOptional[UUID](EntityFields.id, map)
-      pos <- get[List[Double]](EntityFields.position, map)
+      id <- getOptional[UUID](EntityFields.Id, map)
+      pos <- get[List[Double]](EntityFields.Position, map)
       position <- parsePosition(pos)
-      orientation <- getOptional[Double](EntityFields.orientation, map)
-      radius <- getOptional[Double](LightFields.radius, map)
-      illumination <- get[Double](LightFields.illuminationRadius, map)
-      intensity <- getOptional[Double](LightFields.intensity, map)
-      attenuation <- getOptional[Double](LightFields.attenuation, map)
+      orientation <- getOptional[Double](EntityFields.Orientation, map)
+      radius <- getOptional[Double](LightFields.Radius, map)
+      illumination <- get[Double](LightFields.IlluminationRadius, map)
+      intensity <- getOptional[Double](LightFields.Intensity, map)
+      attenuation <- getOptional[Double](LightFields.Attenuation, map)
     yield light.at(position).withIlluminationRadius(illumination)
       |> (l => id.fold(l)(l.withId))
       |> (l => orientation.fold(l)(o => l.withOrientation(Orientation(o))))

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/DynamicEntity.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/DynamicEntity.scala
@@ -7,8 +7,8 @@ import io.circe.{ Encoder, Json }
 import io.github.srs.config.yaml.serializer.encoders.given
 import io.github.srs.model.entity.dynamicentity.Robot
 import io.github.srs.model.entity.dynamicentity.actuator.DifferentialWheelMotor
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.stdProximitySensors
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.stdLightSensors
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.StdProximitySensors
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.StdLightSensors
 import io.github.srs.utils.SimulationDefaults.Fields.Entity as EntityFields
 import io.github.srs.utils.SimulationDefaults.Fields.Entity.DynamicEntity.Robot as RobotFields
 
@@ -34,26 +34,26 @@ object DynamicEntity:
         )
       case _ => ()
 
-    val withProximitySensors = stdProximitySensors.forall(robot.sensors.contains)
-    val withLightSensors = stdLightSensors.forall(robot.sensors.contains)
+    val withProximitySensors = StdProximitySensors.forall(robot.sensors.contains)
+    val withLightSensors = StdLightSensors.forall(robot.sensors.contains)
 
-    if robot.sensors.diff(stdProximitySensors ++ stdLightSensors).sizeIs > 0 then
+    if robot.sensors.diff(StdProximitySensors ++ StdLightSensors).sizeIs > 0 then
       println(
         "WARNING: encoding robot with custom sensors, those will be lost during the serialization",
       )
 
     Json
       .obj(
-        EntityFields.id -> robot.id.asJson,
-        EntityFields.position -> robot.position.asJson,
-        RobotFields.radius -> robot.shape.radius.asJson,
-        EntityFields.orientation -> robot.orientation.degrees.asJson,
-        RobotFields.withProximitySensors -> withProximitySensors.asJson,
-        RobotFields.withLightSensors -> withLightSensors.asJson,
-        RobotFields.behavior -> robot.behavior.toString().asJson,
+        EntityFields.Id -> robot.id.asJson,
+        EntityFields.Position -> robot.position.asJson,
+        RobotFields.Radius -> robot.shape.radius.asJson,
+        EntityFields.Orientation -> robot.orientation.degrees.asJson,
+        RobotFields.WithProximitySensors -> withProximitySensors.asJson,
+        RobotFields.WithLightSensors -> withLightSensors.asJson,
+        RobotFields.Behavior -> robot.behavior.toString().asJson,
       )
       .deepMerge(
-        speeds.map(RobotFields.speed -> _._1.asJson).toList.toMap.asJson,
+        speeds.map(RobotFields.Speed -> _._1.asJson).toList.toMap.asJson,
       )
 
 end DynamicEntity

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Entity.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Entity.scala
@@ -29,13 +29,13 @@ object Entity:
     case e: DynamicEntity =>
       e match
         case r: Robot =>
-          Json.obj(RobotFields.self -> r.asJson)
+          Json.obj(RobotFields.Self -> r.asJson)
     case e: StaticEntity =>
       e match
         case o: StaticEntity.Obstacle =>
-          Json.obj(ObstacleFields.self -> o.asJson)
+          Json.obj(ObstacleFields.Self -> o.asJson)
         case l: StaticEntity.Light =>
-          Json.obj(LightFields.self -> l.asJson)
+          Json.obj(LightFields.Self -> l.asJson)
         case _: StaticEntity.Boundary =>
           Json.obj() // Boundary entities are not serialized
 end Entity

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Environment.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Environment.scala
@@ -22,8 +22,8 @@ object Environment:
    */
   given Encoder[Environment] = (environment: Environment) =>
     val baseFields = List(
-      EnvironmentFields.width -> environment.width.asJson,
-      EnvironmentFields.height -> environment.height.asJson,
+      EnvironmentFields.Width -> environment.width.asJson,
+      EnvironmentFields.Height -> environment.height.asJson,
     )
     val entitiesFields = environment.entities.filterNot {
       case Boundary(_, _, _, _, _) =>
@@ -33,7 +33,7 @@ object Environment:
     if environment.entities.isEmpty then Json.obj(baseFields*)
     else
       Json.obj(
-        baseFields ++ List(EnvironmentFields.entities -> entitiesFields)*,
+        baseFields ++ List(EnvironmentFields.Entities -> entitiesFields)*,
       )
 end Environment
 

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Simulation.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/Simulation.scala
@@ -19,10 +19,10 @@ object Simulation:
     Json
       .obj()
       .deepMerge(
-        simulation.duration.map(SimulationFields.duration -> _.asJson).toList.toMap.asJson,
+        simulation.duration.map(SimulationFields.Duration -> _.asJson).toList.toMap.asJson,
       )
       .deepMerge(
-        simulation.seed.map(SimulationFields.seed -> _.asJson).toList.toMap.asJson,
+        simulation.seed.map(SimulationFields.Seed -> _.asJson).toList.toMap.asJson,
       )
 
 export Simulation.given

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/SimulationConfig.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/SimulationConfig.scala
@@ -22,12 +22,12 @@ object SimulationConfig:
   given Encoder[SimulationConfig[Environment]] =
     (config: SimulationConfig[Environment]) =>
       val baseFields = List(
-        EnvironmentFields.self -> config.environment.asJson,
+        EnvironmentFields.Self -> config.environment.asJson,
       )
 
       val simulationFields =
         if config.simulation.duration.isDefined || config.simulation.seed.isDefined then
-          List(SimulationFields.self -> config.simulation.asJson)
+          List(SimulationFields.Self -> config.simulation.asJson)
         else List.empty[(String, Json)]
 
       Json.obj(simulationFields ++ baseFields*)

--- a/src/main/scala/io/github/srs/config/yaml/serializer/encoders/StaticEntity.scala
+++ b/src/main/scala/io/github/srs/config/yaml/serializer/encoders/StaticEntity.scala
@@ -19,11 +19,11 @@ object StaticEntity:
    */
   given Encoder[Obstacle] = (obs: Obstacle) =>
     Json.obj(
-      EntityFields.id -> obs.id.asJson,
-      EntityFields.position -> obs.position.asJson,
-      EntityFields.orientation -> obs.orientation.degrees.asJson,
-      ObstacleFields.width -> obs.width.asJson,
-      ObstacleFields.height -> obs.height.asJson,
+      EntityFields.Id -> obs.id.asJson,
+      EntityFields.Position -> obs.position.asJson,
+      EntityFields.Orientation -> obs.orientation.degrees.asJson,
+      ObstacleFields.Width -> obs.width.asJson,
+      ObstacleFields.Height -> obs.height.asJson,
     )
 
   /**
@@ -33,13 +33,13 @@ object StaticEntity:
    */
   given Encoder[Light] = (light: Light) =>
     Json.obj(
-      EntityFields.id -> light.id.asJson,
-      EntityFields.position -> light.position.asJson,
-      EntityFields.orientation -> light.orientation.degrees.asJson,
-      LightFields.radius -> light.radius.asJson,
-      LightFields.illuminationRadius -> light.illuminationRadius.asJson,
-      LightFields.intensity -> light.intensity.asJson,
-      LightFields.attenuation -> light.attenuation.asJson,
+      EntityFields.Id -> light.id.asJson,
+      EntityFields.Position -> light.position.asJson,
+      EntityFields.Orientation -> light.orientation.degrees.asJson,
+      LightFields.Radius -> light.radius.asJson,
+      LightFields.IlluminationRadius -> light.illuminationRadius.asJson,
+      LightFields.Intensity -> light.intensity.asJson,
+      LightFields.Attenuation -> light.attenuation.asJson,
     )
 end StaticEntity
 

--- a/src/main/scala/io/github/srs/controller/ControllerModule.scala
+++ b/src/main/scala/io/github/srs/controller/ControllerModule.scala
@@ -15,7 +15,7 @@ import io.github.srs.model.entity.dynamicentity.behavior.BehaviorContext
 import io.github.srs.model.entity.dynamicentity.sensor.Sensor.senseAll
 import io.github.srs.model.logic.*
 import io.github.srs.utils.EqualityGivenInstances.given_CanEqual_Event_Event
-import io.github.srs.utils.SimulationDefaults.debugMode
+import io.github.srs.utils.SimulationDefaults.DebugMode
 
 /**
  * Module that defines the controller logic for the Scala Robotics Simulator.
@@ -129,7 +129,7 @@ object ControllerModule:
                   for
                     nextState <- nextStep(newState, startTime)
                     endTime <- Clock[IO].realTime.map(_.toMillis)
-                    _ <- if debugMode then IO.println(s"Simulation loop took ${endTime - startTime} ms") else IO.unit
+                    _ <- if DebugMode then IO.println(s"Simulation loop took ${endTime - startTime} ms") else IO.unit
                     res <- loop(nextState)
                   yield res
             yield result

--- a/src/main/scala/io/github/srs/model/Simulation.scala
+++ b/src/main/scala/io/github/srs/model/Simulation.scala
@@ -10,8 +10,8 @@ import io.github.srs.utils.SimulationDefaults
  *   The seed for the random number generator. If None, a random seed will be used.
  */
 final case class Simulation(
-    duration: Option[Long] = SimulationDefaults.duration,
-    seed: Option[Long] = SimulationDefaults.seed,
+    duration: Option[Long] = SimulationDefaults.Duration,
+    seed: Option[Long] = SimulationDefaults.Seed,
 )
 
 /**

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/Robot.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/Robot.scala
@@ -23,12 +23,12 @@ import io.github.srs.model.entity.dynamicentity.behavior.Policy
  */
 final case class Robot(
     override val id: UUID = UUID.randomUUID(),
-    override val position: Point2D = defaultPosition,
-    override val shape: ShapeType.Circle = defaultShape,
-    override val orientation: Orientation = defaultOrientation,
-    override val actuators: Seq[Actuator[Robot]] = defaultActuators,
-    override val sensors: Vector[Sensor[Robot, Environment]] = defaultSensors,
-    override val behavior: Policy = defaultPolicy,
+    override val position: Point2D = DefaultPosition,
+    override val shape: ShapeType.Circle = DefaultShape,
+    override val orientation: Orientation = DefaultOrientation,
+    override val actuators: Seq[Actuator[Robot]] = DefaultActuators,
+    override val sensors: Vector[Sensor[Robot, Environment]] = DefaultSensors,
+    override val behavior: Policy = DefaultPolicy,
 ) extends DynamicEntity:
 
   given CanEqual[Policy, Policy] = CanEqual.derived

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/action/MovementActionFactory.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/action/MovementActionFactory.scala
@@ -54,7 +54,7 @@ object MovementActionFactory:
    * @return
    *   the [[MovementAction]] representing the left turn.
    */
-  infix def turnLeft[F[_]]: MovementAction[F] = MovementAction(halfSpeed, -halfSpeed)
+  infix def turnLeft[F[_]]: MovementAction[F] = MovementAction(HalfSpeed, -HalfSpeed)
 
   /**
    * Turns the robot right by applying a negative speed to the left wheel and a positive speed to the right wheel.
@@ -63,7 +63,7 @@ object MovementActionFactory:
    * @return
    *   the [[MovementAction]] representing the right turn.
    */
-  infix def turnRight[F[_]]: MovementAction[F] = MovementAction(-halfSpeed, halfSpeed)
+  infix def turnRight[F[_]]: MovementAction[F] = MovementAction(-HalfSpeed, HalfSpeed)
 
   /**
    * Stops the robot by applying zero speed to both wheels.
@@ -72,7 +72,7 @@ object MovementActionFactory:
    * @return
    *   the [[MovementAction]] representing the stop action.
    */
-  infix def stop[F[_]]: MovementAction[F] = MovementAction(zeroSpeed, zeroSpeed)
+  infix def stop[F[_]]: MovementAction[F] = MovementAction(ZeroSpeed, ZeroSpeed)
 end MovementActionFactory
 
 export io.github.srs.model.entity.dynamicentity.action.SequenceAction.thenDo

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/actuator/DifferentialWheelMotor.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/actuator/DifferentialWheelMotor.scala
@@ -11,7 +11,7 @@ import io.github.srs.model.entity.Point2D.*
 import io.github.srs.model.entity.dynamicentity.Robot
 import io.github.srs.model.entity.dynamicentity.action.{ Action, ActionAlg }
 import io.github.srs.model.entity.dynamicentity.dsl.RobotDsl.*
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Actuator.DifferentialWheelMotor.defaultWheel
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Actuator.DifferentialWheelMotor.DefaultWheel
 import io.github.srs.model.entity.dynamicentity.action.SequenceAction
 
 /**
@@ -48,7 +48,7 @@ object DifferentialWheelMotor:
    * @return
    *   a new instance of [[DifferentialWheelMotor]].
    */
-  def apply(left: Wheel = defaultWheel, right: Wheel = defaultWheel): DifferentialWheelMotor =
+  def apply(left: Wheel = DefaultWheel, right: Wheel = DefaultWheel): DifferentialWheelMotor =
     DifferentialWheelMotorImpl(left, right)
 
   /**

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/actuator/Wheel.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/actuator/Wheel.scala
@@ -11,7 +11,7 @@ import io.github.srs.utils.SimulationDefaults.DynamicEntity.Actuator.Differentia
  * @param shape
  *   the physical shape of the wheel, assumed to be a circle.
  */
-final case class Wheel(speed: Double = defaultSpeed, shape: ShapeType.Circle = defaultShape):
+final case class Wheel(speed: Double = DefaultSpeed, shape: ShapeType.Circle = DefaultShape):
   /**
    * Returns a new instance of this wheel with an updated linear speed.
    *

--- a/src/main/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDsl.scala
+++ b/src/main/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDsl.scala
@@ -166,10 +166,10 @@ object RobotDsl:
       robot.withActuators(updatedActuators)
 
     def withProximitySensors: Robot =
-      robot.withSensors(stdProximitySensors)
+      robot.withSensors(StdProximitySensors)
 
     def withLightSensors: Robot =
-      robot.withSensors(stdLightSensors)
+      robot.withSensors(StdLightSensors)
 
     infix def withBehavior(behavior: Policy): Robot =
       robot.copy(behavior = behavior)

--- a/src/main/scala/io/github/srs/model/entity/staticentity/StaticEntity.scala
+++ b/src/main/scala/io/github/srs/model/entity/staticentity/StaticEntity.scala
@@ -27,10 +27,10 @@ enum StaticEntity(val position: Point2D, val orientation: Orientation) extends E
    */
   case Obstacle(
       id: UUID = UUID.randomUUID(),
-      pos: Point2D = Defaults.Obstacle.defaultPosition,
-      orient: Orientation = Defaults.Obstacle.defaultOrientation,
-      width: Double = Defaults.Obstacle.defaultWidth,
-      height: Double = Defaults.Obstacle.defaultHeight,
+      pos: Point2D = Defaults.Obstacle.DefaultPosition,
+      orient: Orientation = Defaults.Obstacle.DefaultOrientation,
+      width: Double = Defaults.Obstacle.DefaultWidth,
+      height: Double = Defaults.Obstacle.DefaultHeight,
   ) extends StaticEntity(pos, orient)
 
   /**
@@ -51,12 +51,12 @@ enum StaticEntity(val position: Point2D, val orientation: Orientation) extends E
    */
   case Light(
       id: UUID = UUID.randomUUID(),
-      pos: Point2D = Defaults.Light.defaultPosition,
-      orient: Orientation = Defaults.Light.defaultOrientation,
-      radius: Double = SimulationDefaults.StaticEntity.Light.defaultRadius,
-      illuminationRadius: Double = SimulationDefaults.StaticEntity.Light.defaultIlluminationRadius,
-      intensity: Double = SimulationDefaults.StaticEntity.Light.defaultIntensity,
-      attenuation: Double = SimulationDefaults.StaticEntity.Light.defaultAttenuation,
+      pos: Point2D = Defaults.Light.DefaultPosition,
+      orient: Orientation = Defaults.Light.DefaultOrientation,
+      radius: Double = SimulationDefaults.StaticEntity.Light.DefaultRadius,
+      illuminationRadius: Double = SimulationDefaults.StaticEntity.Light.DefaultIlluminationRadius,
+      intensity: Double = SimulationDefaults.StaticEntity.Light.DefaultIntensity,
+      attenuation: Double = SimulationDefaults.StaticEntity.Light.DefaultAttenuation,
   ) extends StaticEntity(pos, orient)
 
   /**
@@ -72,10 +72,10 @@ enum StaticEntity(val position: Point2D, val orientation: Orientation) extends E
    */
   case Boundary(
       id: UUID = UUID.randomUUID(),
-      pos: Point2D = Defaults.Boundary.defaultPosition,
-      orient: Orientation = Defaults.Boundary.defaultOrientation,
-      width: Double = Defaults.Boundary.defaultWidth,
-      height: Double = Defaults.Boundary.defaultHeight,
+      pos: Point2D = Defaults.Boundary.DefaultPosition,
+      orient: Orientation = Defaults.Boundary.DefaultOrientation,
+      width: Double = Defaults.Boundary.DefaultWidth,
+      height: Double = Defaults.Boundary.DefaultHeight,
   ) extends StaticEntity(pos, orient)
 
   /**

--- a/src/main/scala/io/github/srs/model/environment/Environment.scala
+++ b/src/main/scala/io/github/srs/model/environment/Environment.scala
@@ -56,13 +56,13 @@ end EnvironmentParameters
  * Represents an environment with a specific width, height, and a set of entities.
  */
 final case class Environment(
-    override val width: Int = defaultWidth,
-    override val height: Int = defaultHeight,
-    override val entities: Set[Entity] = defaultEntities,
+    override val width: Int = DefaultWidth,
+    override val height: Int = DefaultHeight,
+    override val entities: Set[Entity] = DefaultEntities,
     private[environment] val _lightMap: Option[LightMap[IO]] = None,
 ) extends EnvironmentParameters:
 
-  private val lightMap: LightMap[IO] = _lightMap.getOrElse(LightMapConfigs.baseLightMap)
+  private val lightMap: LightMap[IO] = _lightMap.getOrElse(LightMapConfigs.BaseLightMap)
 
   lazy val lightField: LightField =
     lightMap.computeField(ValidEnvironment.from(this), includeDynamic = true).unsafeRunSync()

--- a/src/main/scala/io/github/srs/model/environment/dsl/CreationDSL.scala
+++ b/src/main/scala/io/github/srs/model/environment/dsl/CreationDSL.scala
@@ -53,7 +53,7 @@ object CreationDSL:
      * Use simple lighting without caching
      */
     def withDefaultLighting: Environment =
-      env.copy(_lightMap = Some(LightMapConfigs.baseLightMap))
+      env.copy(_lightMap = Some(LightMapConfigs.BaseLightMap))
 
     /**
      * Sets the height of the environment.
@@ -107,9 +107,9 @@ object CreationDSL:
       val robots = env.entities.collect:
         case r: Robot => r
       for
-        width <- bounded("width", env.width, minWidth, maxWidth, includeMax = true)
-        height <- bounded("height", env.height, minHeight, maxHeight, includeMax = true)
-        _ <- bounded("entities", env.entities.size, 0, maxEntities, includeMax = true)
+        width <- bounded("width", env.width, MinWidth, MaxWidth, includeMax = true)
+        height <- bounded("height", env.height, MinHeight, MaxHeight, includeMax = true)
+        _ <- bounded("entities", env.entities.size, 0, MaxEntities, includeMax = true)
         entities <- withinBounds("entities", entities, width, height)
         entities <- noCollisions("entities", entities ++ boundaries)
         _ <- robots.toList.traverse_(validateRobot)

--- a/src/main/scala/io/github/srs/model/logic/RobotActionsLogic.scala
+++ b/src/main/scala/io/github/srs/model/logic/RobotActionsLogic.scala
@@ -13,8 +13,8 @@ import io.github.srs.model.environment.ValidEnvironment.ValidEnvironment
 import io.github.srs.model.environment.dsl.CreationDSL.validate
 import io.github.srs.model.{ ModelModule, SimulationState }
 import io.github.srs.utils.EqualityGivenInstances.given
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.defaultMaxRetries
-import io.github.srs.utils.SimulationDefaults.{ binarySearchDurationThreshold, debugMode }
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.DefaultMaxRetries
+import io.github.srs.utils.SimulationDefaults.{ BinarySearchDurationThreshold, DebugMode }
 
 /**
  * Logic for handling robot actions proposals.
@@ -70,7 +70,7 @@ object RobotActionsLogic:
           robot: Robot,
           action: Action[IO],
           maxDt: FiniteDuration,
-          maxAttempts: Int = defaultMaxRetries,
+          maxAttempts: Int = DefaultMaxRetries,
       ): IO[Robot] =
 
         /**
@@ -87,7 +87,7 @@ object RobotActionsLogic:
          *   an [[IO]] effect that produces the best valid robot found.
          */
         def binarySearch(low: FiniteDuration, high: FiniteDuration, best: Option[Robot], attempts: Int): IO[Robot] =
-          if attempts >= maxAttempts || (high - low) <= binarySearchDurationThreshold then
+          if attempts >= maxAttempts || (high - low) <= BinarySearchDurationThreshold then
             IO.pure(best.getOrElse(robot))
           else
             val mid = low + (high - low) / 2
@@ -140,7 +140,7 @@ object RobotActionsLogic:
           val candidate = applyAllMoves(s.environment, moves)
           candidate.validate match
             case Right(validEnv) =>
-              if debugMode then
+              if DebugMode then
                 moves.foreach { case (_, newR) =>
                   println(s"[${newR.position._1}, ${newR.position._2}],")
                 }

--- a/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
+++ b/src/main/scala/io/github/srs/utils/SimulationDefaults.scala
@@ -83,36 +83,36 @@ object SimulationDefaults:
     end Colors
 
     object Fonts:
-      val fontSize = 12
-      val titleSize = 12
+      val FontSize = 12
+      val TitleSize = 12
 
     object Spacing:
-      val standardPadding = 10
-      val innerPadding = 5
-      val componentGap = 10
+      val StandardPadding = 10
+      val InnerPadding = 5
+      val ComponentGap = 10
 
     object Dimensions:
-      val buttonWidth = 150
-      val buttonHeight = 30
-      val robotListWidth = 250
-      val robotListHeight = 300
-      val infoAreaRows = 6
-      val infoAreaColumns = 25
+      val ButtonWidth = 150
+      val ButtonHeight = 30
+      val RobotListWidth = 250
+      val RobotListHeight = 300
+      val InfoAreaRows = 6
+      val InfoAreaColumns = 25
 
     object Strokes:
-      val obstacleStroke = 1.5f
-      val robotShadowStroke = 3f
+      val ObstacleStroke = 1.5f
+      val RobotShadowStroke = 3f
 
     object Icons:
-      val play = "\u25B6"
-      val stop = "\u23F9"
-      val pause = "\u23F8"
+      val Play = "\u25B6"
+      val Stop = "\u23F9"
+      val Pause = "\u23F8"
   end UI
 
-  val duration: Option[Long] = None
-  val seed: Option[Long] = None
-  val debugMode = true
-  val binarySearchDurationThreshold: FiniteDuration = 1.microseconds
+  val Duration: Option[Long] = None
+  val Seed: Option[Long] = None
+  val DebugMode = true
+  val BinarySearchDurationThreshold: FiniteDuration = 1.microseconds
 
   /**
    * Alternative light map configurations for different use cases
@@ -122,7 +122,7 @@ object SimulationDefaults:
     /**
      * Default light map with caching enabled Uses scale factor 10 for a good balance of performance and precision
      */
-    lazy val baseLightMap: LightMap[IO] =
+    lazy val BaseLightMap: LightMap[IO] =
       LightMap
         .create[IO](ScaleFactor.default, SquidLibFovEngine)
         .unsafeRunSync()
@@ -141,7 +141,7 @@ object SimulationDefaults:
             .create[IO](scale, SquidLibFovEngine)
             .unsafeRunSync()
         }
-        .getOrElse(baseLightMap)
+        .getOrElse(BaseLightMap)
 
     /**
      * Fast light map for real-time simulation Uses scale factor 5 for maximum performance.
@@ -157,7 +157,7 @@ object SimulationDefaults:
             .create[IO](scale, SquidLibFovEngine)
             .unsafeRunSync()
         }
-        .getOrElse(baseLightMap)
+        .getOrElse(BaseLightMap)
 
     /**
      * Custom light map with specific scale factor Curried for better composition.
@@ -176,65 +176,65 @@ object SimulationDefaults:
             .create[IO](scale, SquidLibFovEngine)
             .unsafeRunSync()
         }
-        .getOrElse(baseLightMap)
+        .getOrElse(BaseLightMap)
 
   end LightMapConfigs
 
   object SimulationConfig:
-    val maxCount = 10_000
+    val MaxCount = 10_000
 
   object Environment:
-    val defaultWidth: Int = 10
-    val minWidth: Int = 1
-    val maxWidth: Int = 500
+    val DefaultWidth: Int = 10
+    val MinWidth: Int = 1
+    val MaxWidth: Int = 500
 
-    val defaultHeight: Int = 10
-    val minHeight: Int = 1
-    val maxHeight: Int = 500
+    val DefaultHeight: Int = 10
+    val MinHeight: Int = 1
+    val MaxHeight: Int = 500
 
-    val defaultEntities: Set[Entity] = Set.empty
-    val maxEntities: Int = 200
+    val DefaultEntities: Set[Entity] = Set.empty
+    val MaxEntities: Int = 200
 
   object StaticEntity:
 
     object Obstacle:
-      val defaultId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
-      val defaultPosition: Point2D = (0.0, 0.0)
-      val defaultOrientation: Orientation = Orientation(0.0)
-      val defaultWidth: Double = 1.0
-      val defaultHeight: Double = 1.0
+      val DefaultId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+      val DefaultPosition: Point2D = (0.0, 0.0)
+      val DefaultOrientation: Orientation = Orientation(0.0)
+      val DefaultWidth: Double = 1.0
+      val DefaultHeight: Double = 1.0
 
     object Light:
-      val defaultId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
-      val defaultPosition: Point2D = (0.0, 0.0)
-      val defaultOrientation: Orientation = Orientation(0.0)
-      val defaultRadius: Double = 0.05
-      val defaultIlluminationRadius: Double = 1.0
-      val defaultIntensity: Double = 1.0
-      val defaultAttenuation: Double = 1.0
+      val DefaultId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+      val DefaultPosition: Point2D = (0.0, 0.0)
+      val DefaultOrientation: Orientation = Orientation(0.0)
+      val DefaultRadius: Double = 0.05
+      val DefaultIlluminationRadius: Double = 1.0
+      val DefaultIntensity: Double = 1.0
+      val DefaultAttenuation: Double = 1.0
 
     object Boundary:
-      val defaultPosition: Point2D = (0.0, 0.0)
-      val defaultOrientation: Orientation = Orientation(0.0)
-      val defaultWidth: Double = 1.0
-      val defaultHeight: Double = 1.0
+      val DefaultPosition: Point2D = (0.0, 0.0)
+      val DefaultOrientation: Orientation = Orientation(0.0)
+      val DefaultWidth: Double = 1.0
+      val DefaultHeight: Double = 1.0
 
   end StaticEntity
 
   object DynamicEntity:
-    val zeroSpeed: Double = 0.0
+    val ZeroSpeed: Double = 0.0
     val MinSpeed: Double = -1.0
     val MaxSpeed: Double = 1.0
-    val halfSpeed: Double = 0.5
+    val HalfSpeed: Double = 0.5
 
     object Actuator:
 
       object DifferentialWheelMotor:
-        val defaultWheel: ActWheel = ActWheel()
+        val DefaultWheel: ActWheel = ActWheel()
 
         object Wheel:
-          val defaultSpeed: Double = 1.0
-          val defaultShape: ShapeType.Circle = ShapeType.Circle(0.1)
+          val DefaultSpeed: Double = 1.0
+          val DefaultShape: ShapeType.Circle = ShapeType.Circle(0.1)
           val MinSpeed: Double = -1.0
           val MaxSpeed: Double = 1.0
 
@@ -246,24 +246,24 @@ object SimulationDefaults:
 
     object Robot:
 
-      val defaultMaxRetries = 10
+      val DefaultMaxRetries = 10
 
-      val defaultId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
-      val defaultPosition: Point2D = (0.0, 0.0)
-      val defaultShape: ShapeType.Circle = ShapeType.Circle(0.25)
-      val defaultOrientation: Orientation = Orientation(0.0)
-      val defaultActuators: Seq[Actuator[Robot]] = Seq.empty
-      val defaultSensors: Vector[Sensor[Robot, Environment]] = Vector.empty
+      val DefaultId: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+      val DefaultPosition: Point2D = (0.0, 0.0)
+      val DefaultShape: ShapeType.Circle = ShapeType.Circle(0.25)
+      val DefaultOrientation: Orientation = Orientation(0.0)
+      val DefaultActuators: Seq[Actuator[Robot]] = Seq.empty
+      val DefaultSensors: Vector[Sensor[Robot, Environment]] = Vector.empty
       val MinRadius: Double = 0.01
       val MaxRadius: Double = 0.5
 
-      val selectionStroke: Float = 3f
-      val normalStroke: Float = 1f
-      val arrowLengthFactor: Double = 0.6
-      val arrowWidthFactor: Double = 0.3
-      val minArrowWidth: Float = 2f
+      val SelectionStroke: Float = 3f
+      val NormalStroke: Float = 1f
+      val ArrowLengthFactor: Double = 0.6
+      val ArrowWidthFactor: Double = 0.3
+      val MinArrowWidth: Float = 2f
 
-      val stdProximitySensors: Vector[Sensor[Robot, Environment]] = Vector(
+      val StdProximitySensors: Vector[Sensor[Robot, Environment]] = Vector(
         ProximitySensor(Orientation(0.0)),
         ProximitySensor(Orientation(45.0)),
         ProximitySensor(Orientation(90.0)),
@@ -274,7 +274,7 @@ object SimulationDefaults:
         ProximitySensor(Orientation(315.0)),
       )
 
-      val stdLightSensors: Vector[Sensor[Robot, Environment]] = Vector(
+      val StdLightSensors: Vector[Sensor[Robot, Environment]] = Vector(
         LightSensor(Orientation(0.0)),
         LightSensor(Orientation(45.0)),
         LightSensor(Orientation(90.0)),
@@ -284,84 +284,84 @@ object SimulationDefaults:
         LightSensor(Orientation(270.0)),
         LightSensor(Orientation(315.0)),
       )
-      val defaultPolicy: Policy = Policy.AlwaysForward
+      val DefaultPolicy: Policy = Policy.AlwaysForward
     end Robot
   end DynamicEntity
 
   object Fields:
 
     object Simulation:
-      val self: String = "simulation"
-      val duration: String = "duration"
-      val seed: String = "seed"
+      val Self: String = "simulation"
+      val Duration: String = "duration"
+      val Seed: String = "seed"
 
     object Environment:
-      val self: String = "environment"
-      val width: String = "width"
-      val height: String = "height"
-      val entities: String = "entities"
+      val Self: String = "environment"
+      val Width: String = "width"
+      val Height: String = "height"
+      val Entities: String = "entities"
 
     object Entity:
-      val id: String = "id"
-      val position: String = "position"
-      val x: String = "x"
-      val y: String = "y"
-      val orientation: String = "orientation"
+      val Id: String = "id"
+      val Position: String = "position"
+      val X: String = "x"
+      val Y: String = "y"
+      val Orientation: String = "orientation"
 
       object StaticEntity:
 
         object Obstacle:
-          val self: String = "obstacle"
-          val width: String = "width"
-          val height: String = "height"
+          val Self: String = "obstacle"
+          val Width: String = "width"
+          val Height: String = "height"
 
         object Light:
-          val self: String = "light"
-          val radius: String = "radius"
-          val illuminationRadius: String = "illuminationRadius"
-          val intensity: String = "intensity"
-          val attenuation: String = "attenuation"
+          val Self: String = "light"
+          val Radius: String = "radius"
+          val IlluminationRadius: String = "illuminationRadius"
+          val Intensity: String = "intensity"
+          val Attenuation: String = "attenuation"
 
       object DynamicEntity:
 
         object Robot:
-          val self: String = "robot"
-          val radius: String = "radius"
-          val speed: String = "speed"
-          val withProximitySensors: String = "withProximitySensors"
-          val withLightSensors: String = "withLightSensors"
-          val behavior: String = "behavior"
+          val Self: String = "robot"
+          val Radius: String = "radius"
+          val Speed: String = "speed"
+          val WithProximitySensors: String = "withProximitySensors"
+          val WithLightSensors: String = "withLightSensors"
+          val Behavior: String = "behavior"
     end Entity
   end Fields
 
   object Layout:
-    val splitPaneWeight: Double = 0.8
-    val splitPaneLocation: Double = 0.8
+    val SplitPaneWeight: Double = 0.8
+    val SplitPaneLocation: Double = 0.8
 
   object Frame:
-    val minWidth = 800
-    val minHeight = 600
-    val prefWidth = 1200
-    val prefHeight = 720
-    val splitWeight = 0.8
-    val canvasBorder: Int = 2
+    val MinWidth = 800
+    val MinHeight = 600
+    val PrefWidth = 1200
+    val PrefHeight = 720
+    val SplitWeight = 0.8
+    val CanvasBorder: Int = 2
 
   object Canvas:
-    val borderSize = 2
-    val minZoom = 0.2
-    val maxZoom = 5.0
-    val zoomInFactor = 1.2
-    val zoomOutFactor = 0.8
-    val desiredLabelPixels = 40.0
-    val gridStrokeWidth = 1f
-    val labelDesiredPx: Double = 40.0
-    val minLightSize: Int = 12
-    val lightStroke: Float = 2f
-    val labelBottomOffset: Int = 4
-    val labelYOffset: Int = 12
-    val labelXOffset: Int = 2
+    val BorderSize = 2
+    val MinZoom = 0.2
+    val MaxZoom = 5.0
+    val ZoomInFactor = 1.2
+    val ZoomOutFactor = 0.8
+    val DesiredLabelPixels = 40.0
+    val GridStrokeWidth = 1f
+    val LabelDesiredPx: Double = 40.0
+    val MinLightSize: Int = 12
+    val LightStroke: Float = 2f
+    val LabelBottomOffset: Int = 4
+    val LabelYOffset: Int = 12
+    val LabelXOffset: Int = 2
 
   object ControlsPanel:
-    val startStopButtonText: String = "Start/Stop"
+    val StartStopButtonText: String = "Start/Stop"
 
 end SimulationDefaults

--- a/src/main/scala/io/github/srs/view/ConfigurationGUI.scala
+++ b/src/main/scala/io/github/srs/view/ConfigurationGUI.scala
@@ -20,8 +20,8 @@ import io.github.srs.view.components.*
 import io.github.srs.view.components.configuration.*
 import io.github.srs.view.components.simulation.SimulationCanvas
 import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.*
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Actuator.DifferentialWheelMotor.Wheel.defaultSpeed
-import io.github.srs.utils.SimulationDefaults.StaticEntity.Obstacle.{ defaultHeight, defaultWidth }
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Actuator.DifferentialWheelMotor.Wheel.DefaultSpeed
+import io.github.srs.utils.SimulationDefaults.StaticEntity.Obstacle.{ DefaultHeight, DefaultWidth }
 import io.github.srs.utils.SimulationDefaults.StaticEntity.Light
 
 /**
@@ -42,47 +42,43 @@ object ConfigurationGUI:
     private val frame = new JFrame("Scala Robotics Simulator - Configuration")
 
     private val baseFieldSpec = Seq(
-      FieldSpec(Entity.x, "X position", TextField(3, default = defaultPosition.x.toString)),
-      FieldSpec(Entity.y, "Y position", TextField(3, default = defaultPosition.y.toString)),
+      FieldSpec(Entity.X, "X position", TextField(3, default = DefaultPosition.x.toString)),
+      FieldSpec(Entity.Y, "Y position", TextField(3, default = DefaultPosition.y.toString)),
       FieldSpec(
-        Entity.orientation,
+        Entity.Orientation,
         "Orientation (degrees)",
-        TextField(3, default = defaultOrientation.degrees.toString),
+        TextField(3, default = DefaultOrientation.degrees.toString),
       ),
     )
 
     private val entityFieldSpecs: Map[String, Seq[FieldSpec]] = Map(
-      RobotFields.self.capitalize -> (baseFieldSpec ++ Seq(
-        FieldSpec(RobotFields.radius, "Radius (meters)", TextField(2, default = defaultShape.radius.toString)),
-        FieldSpec(RobotFields.speed, "Speed", TextField(3, default = defaultSpeed.toString)),
-        FieldSpec(RobotFields.withProximitySensors, "With proximity sensors", CheckBox(true)),
-        FieldSpec(RobotFields.withLightSensors, "With light sensors", CheckBox(true)),
-        FieldSpec(RobotFields.behavior, "Behavior", ComboBox(Policy.values.toSeq.map(_.toString))),
+      RobotFields.Self.capitalize -> (baseFieldSpec ++ Seq(
+        FieldSpec(RobotFields.Radius, "Radius (meters)", TextField(2, default = DefaultShape.radius.toString)),
+        FieldSpec(RobotFields.Speed, "Speed", TextField(3, default = DefaultSpeed.toString)),
+        FieldSpec(RobotFields.WithProximitySensors, "With proximity sensors", CheckBox(true)),
+        FieldSpec(RobotFields.WithLightSensors, "With light sensors", CheckBox(true)),
+        FieldSpec(RobotFields.Behavior, "Behavior", ComboBox(Policy.values.toSeq.map(_.toString))),
       )),
-      ObstacleFields.self.capitalize -> (baseFieldSpec ++ Seq(
-        FieldSpec(ObstacleFields.width, "Width", TextField(8, default = defaultWidth.toString)),
-        FieldSpec(ObstacleFields.height, "Height", TextField(5, default = defaultHeight.toString)),
+      ObstacleFields.Self.capitalize -> (baseFieldSpec ++ Seq(
+        FieldSpec(ObstacleFields.Width, "Width", TextField(8, default = DefaultWidth.toString)),
+        FieldSpec(ObstacleFields.Height, "Height", TextField(5, default = DefaultHeight.toString)),
       )),
-      LightFields.self.capitalize -> (baseFieldSpec ++ Seq(
-        FieldSpec(LightFields.radius, "Radius (meters)", TextField(3, default = Light.defaultRadius.toString)),
+      LightFields.Self.capitalize -> (baseFieldSpec ++ Seq(
+        FieldSpec(LightFields.Radius, "Radius (meters)", TextField(3, default = Light.DefaultRadius.toString)),
         FieldSpec(
-          LightFields.illuminationRadius,
+          LightFields.IlluminationRadius,
           "Illumination radius",
-          TextField(3, default = Light.defaultIlluminationRadius.toString),
+          TextField(3, default = Light.DefaultIlluminationRadius.toString),
         ),
-        FieldSpec(LightFields.intensity, "Intensity", TextField(3, Light.defaultIntensity.toString)),
-        FieldSpec(LightFields.attenuation, "Attenuation", TextField(3, Light.defaultAttenuation.toString)),
+        FieldSpec(LightFields.Intensity, "Intensity", TextField(3, Light.DefaultIntensity.toString)),
+        FieldSpec(LightFields.Attenuation, "Attenuation", TextField(3, Light.DefaultAttenuation.toString)),
       )),
     )
 
     // Component panels with callbacks
-    private val simulationPanel = new SimulationSettingsPanel(
-      onValidationError = showValidationErrors,
-    )
+    private val simulationPanel = new SimulationSettingsPanel
 
-    private val environmentPanel = new EnvironmentSettingsPanel(
-      onValidationError = showValidationErrors,
-    )
+    private val environmentPanel = new EnvironmentSettingsPanel
 
     private val fieldCanvas = new SimulationCanvas(insideConfiguration = true)
 

--- a/src/main/scala/io/github/srs/view/GUIComponent.scala
+++ b/src/main/scala/io/github/srs/view/GUIComponent.scala
@@ -42,7 +42,6 @@ trait GUIComponent[S <: ModelModule.State] extends Component[S]:
     import io.github.srs.model.SimulationConfig.SimulationSpeed
     import io.github.srs.utils.SimulationDefaults.{ Frame, Layout }
 
-    type RobotId = String
     private type SpeedLabel = String
 
     private val frame = new JFrame("Scala Robotics Simulator")
@@ -83,7 +82,7 @@ trait GUIComponent[S <: ModelModule.State] extends Component[S]:
     private def setupUI(): Unit =
       import io.github.srs.view.components.{ applyDefaultAndPreferSize, centerFrame }
 
-      canvas.setBorder(BorderFactory.createLineBorder(java.awt.Color.BLACK, Frame.canvasBorder))
+      canvas.setBorder(BorderFactory.createLineBorder(java.awt.Color.BLACK, Frame.CanvasBorder))
       frame.applyDefaultAndPreferSize()
       frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE)
 
@@ -92,8 +91,8 @@ trait GUIComponent[S <: ModelModule.State] extends Component[S]:
         canvas,
         createSidePanel(),
       )
-      splitPane.setResizeWeight(Layout.splitPaneWeight)
-      splitPane.setDividerLocation(Layout.splitPaneLocation)
+      splitPane.setResizeWeight(Layout.SplitPaneWeight)
+      splitPane.setDividerLocation(Layout.SplitPaneLocation)
 
       frame.add(splitPane, BorderLayout.CENTER)
       frame.pack()

--- a/src/main/scala/io/github/srs/view/components/UIUtils.scala
+++ b/src/main/scala/io/github/srs/view/components/UIUtils.scala
@@ -12,7 +12,7 @@ import io.github.srs.utils.SimulationDefaults.{ Frame, UI }
  */
 object UIUtils:
 
-  def titledBorder(title: String, spacing: Int = UI.Spacing.innerPadding): javax.swing.border.Border =
+  def titledBorder(title: String, spacing: Int = UI.Spacing.InnerPadding): javax.swing.border.Border =
     val titledBorder = BorderFactory.createTitledBorder(
       BorderFactory.createLineBorder(UI.Colors.border),
       title.toUpperCase(Locale.getDefault()),
@@ -24,7 +24,7 @@ object UIUtils:
     val newFont = new Font(
       currentFont.getFamily,
       currentFont.getStyle,
-      UI.Fonts.titleSize,
+      UI.Fonts.TitleSize,
     )
     titledBorder.setTitleFont(newFont)
 
@@ -35,7 +35,7 @@ object UIUtils:
 
   end titledBorder
 
-  def paddedBorder(padding: Int = UI.Spacing.standardPadding): javax.swing.border.Border =
+  def paddedBorder(padding: Int = UI.Spacing.StandardPadding): javax.swing.border.Border =
     BorderFactory.createEmptyBorder(padding, padding, padding, padding)
 
 end UIUtils
@@ -56,5 +56,5 @@ extension (frame: javax.swing.JFrame)
    * Applies default and preferred size to the frame.
    */
   def applyDefaultAndPreferSize(): Unit =
-    frame.setMinimumSize(new Dimension(Frame.minWidth, Frame.minHeight))
-    frame.setPreferredSize(new Dimension(Frame.prefWidth, Frame.prefHeight))
+    frame.setMinimumSize(new Dimension(Frame.MinWidth, Frame.MinHeight))
+    frame.setPreferredSize(new Dimension(Frame.PrefWidth, Frame.PrefHeight))

--- a/src/main/scala/io/github/srs/view/components/configuration/EntitiesPanel.scala
+++ b/src/main/scala/io/github/srs/view/components/configuration/EntitiesPanel.scala
@@ -11,8 +11,8 @@ import io.github.srs.config.yaml.parser.collection.CustomSeq.sequence
 import io.github.srs.model.entity.staticentity.StaticEntity
 import io.github.srs.model.entity.dynamicentity.Robot
 import io.github.srs.model.entity.dynamicentity.actuator.DifferentialWheelMotor
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.stdProximitySensors
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.stdLightSensors
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.StdProximitySensors
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.StdLightSensors
 import io.github.srs.model.entity.ShapeType
 import io.github.srs.utils.SimulationDefaults.Fields.Entity as EntityFields
 import io.github.srs.utils.SimulationDefaults.Fields.Entity.DynamicEntity.Robot as RobotFields
@@ -94,48 +94,48 @@ class EntitiesPanel(fieldSpecsByType: Map[String, Seq[FieldSpec]]) extends JPane
     entities.foreach(e =>
       e match
         case robot: Robot =>
-          val row = new EntityRow(RobotFields.self.capitalize, fieldSpecsByType, removeEntityRow)
+          val row = new EntityRow(RobotFields.Self.capitalize, fieldSpecsByType, removeEntityRow)
           entityListPanel.add(row)
           val robotMap = Map(
-            EntityFields.x -> robot.position.x.toString,
-            EntityFields.y -> robot.position.y.toString,
-            EntityFields.orientation -> robot.orientation.degrees.toString,
-            RobotFields.radius -> robot.shape.radius.toString,
-            RobotFields.speed -> robot.actuators.collectFirst { case dwt: DifferentialWheelMotor =>
+            EntityFields.X -> robot.position.x.toString,
+            EntityFields.Y -> robot.position.y.toString,
+            EntityFields.Orientation -> robot.orientation.degrees.toString,
+            RobotFields.Radius -> robot.shape.radius.toString,
+            RobotFields.Speed -> robot.actuators.collectFirst { case dwt: DifferentialWheelMotor =>
               dwt.left.speed.toString
             }.getOrElse(""),
-            RobotFields.withProximitySensors -> stdProximitySensors.forall(robot.sensors.contains),
-            RobotFields.withLightSensors -> stdLightSensors.forall(robot.sensors.contains),
-            RobotFields.behavior -> robot.behavior.toString(),
+            RobotFields.WithProximitySensors -> StdProximitySensors.forall(robot.sensors.contains),
+            RobotFields.WithLightSensors -> StdLightSensors.forall(robot.sensors.contains),
+            RobotFields.Behavior -> robot.behavior.toString(),
           )
           row.setValues(robotMap)
         case obs: StaticEntity.Obstacle =>
-          val row = new EntityRow(ObstacleFields.self.capitalize, fieldSpecsByType, removeEntityRow)
+          val row = new EntityRow(ObstacleFields.Self.capitalize, fieldSpecsByType, removeEntityRow)
           entityListPanel.add(row)
           val shapeMap: Map[String, String | Boolean] = obs.shape match
             case ShapeType.Circle(_) => Map.empty[String, String | Boolean]
             case ShapeType.Rectangle(width, height) =>
               Map(
-                ObstacleFields.width -> width.toString,
-                ObstacleFields.height -> height.toString,
+                ObstacleFields.Width -> width.toString,
+                ObstacleFields.Height -> height.toString,
               )
           val obstacleMap = Map(
-            EntityFields.x -> obs.position.x.toString,
-            EntityFields.y -> obs.position.y.toString,
-            EntityFields.orientation -> obs.orientation.degrees.toString,
+            EntityFields.X -> obs.position.x.toString,
+            EntityFields.Y -> obs.position.y.toString,
+            EntityFields.Orientation -> obs.orientation.degrees.toString,
           ) ++ shapeMap
           row.setValues(obstacleMap)
         case light: StaticEntity.Light =>
-          val row = new EntityRow(LightFields.self.capitalize, fieldSpecsByType, removeEntityRow)
+          val row = new EntityRow(LightFields.Self.capitalize, fieldSpecsByType, removeEntityRow)
           entityListPanel.add(row)
           val lightMap = Map(
-            EntityFields.x -> light.position.x.toString,
-            EntityFields.y -> light.position.y.toString,
-            EntityFields.orientation -> light.orientation.degrees.toString,
-            LightFields.radius -> light.radius.toString,
-            LightFields.illuminationRadius -> light.illuminationRadius.toString,
-            LightFields.intensity -> light.intensity.toString,
-            LightFields.attenuation -> light.attenuation.toString,
+            EntityFields.X -> light.position.x.toString,
+            EntityFields.Y -> light.position.y.toString,
+            EntityFields.Orientation -> light.orientation.degrees.toString,
+            LightFields.Radius -> light.radius.toString,
+            LightFields.IlluminationRadius -> light.illuminationRadius.toString,
+            LightFields.Intensity -> light.intensity.toString,
+            LightFields.Attenuation -> light.attenuation.toString,
           )
           row.setValues(lightMap)
       end match

--- a/src/main/scala/io/github/srs/view/components/configuration/EntityRow.scala
+++ b/src/main/scala/io/github/srs/view/components/configuration/EntityRow.scala
@@ -79,7 +79,7 @@ class EntityRow(
   add(new JSeparator(SwingConstants.HORIZONTAL), BorderLayout.SOUTH)
 
   typeCombo.addActionListener(_ =>
-    typeCombo.getSelectedItem() match
+    typeCombo.getSelectedItem match
       case selected: String => cardLayout.show(propertiesContainer, selected)
       case _ => (),
   )
@@ -103,9 +103,9 @@ class EntityRow(
 
   def getEntity: ConfigResult[Entity] =
     getEntityType.toLowerCase(Locale.ENGLISH) match
-      case RobotFields.self => parseRobot()
-      case ObstacleFields.self => parseObstacle()
-      case LightFields.self => parseLight()
+      case RobotFields.Self => parseRobot()
+      case ObstacleFields.Self => parseObstacle()
+      case LightFields.Self => parseLight()
 
   def setValues(values: Map[String, String | Boolean]): Unit =
     getCurrentPropertiesPanel.setValues(values)
@@ -114,14 +114,14 @@ class EntityRow(
     import Decoder.{ get, given }
     val map = getCurrentPropertiesPanel.getValues
     for
-      x <- get[Double](EntityFields.x, map)
-      y <- get[Double](EntityFields.y, map)
-      orientation <- get[Double](EntityFields.orientation, map)
-      radius <- get[Double](RobotFields.radius, map)
-      speed <- get[Double](RobotFields.speed, map)
-      prox <- get[Boolean](RobotFields.withProximitySensors, map)
-      light <- get[Boolean](RobotFields.withLightSensors, map)
-      behavior <- get[Policy](RobotFields.behavior, map)
+      x <- get[Double](EntityFields.X, map)
+      y <- get[Double](EntityFields.Y, map)
+      orientation <- get[Double](EntityFields.Orientation, map)
+      radius <- get[Double](RobotFields.Radius, map)
+      speed <- get[Double](RobotFields.Speed, map)
+      prox <- get[Boolean](RobotFields.WithProximitySensors, map)
+      light <- get[Boolean](RobotFields.WithLightSensors, map)
+      behavior <- get[Policy](RobotFields.Behavior, map)
     yield robot
       .at((x, y))
       .withOrientation(Orientation(orientation))
@@ -137,29 +137,29 @@ class EntityRow(
     import Decoder.{ get, given }
     val map = getCurrentPropertiesPanel.getValues
     for
-      x <- get[Double](EntityFields.x, map)
-      y <- get[Double](EntityFields.y, map)
-      orientation <- get[Double](EntityFields.orientation, map)
-      width <- get[Double](ObstacleFields.width, map)
-      height <- get[Double](ObstacleFields.height, map)
+      x <- get[Double](EntityFields.X, map)
+      y <- get[Double](EntityFields.Y, map)
+      orientation <- get[Double](EntityFields.Orientation, map)
+      width <- get[Double](ObstacleFields.Width, map)
+      height <- get[Double](ObstacleFields.Height, map)
     yield obstacle at (x, y) withOrientation Orientation(orientation) withWidth width withHeight height
 
   private def parseLight(): ConfigResult[StaticEntity.Light] =
     import Decoder.{ get, given }
     val map = getCurrentPropertiesPanel.getValues
     for
-      x <- get[Double](EntityFields.x, map)
-      y <- get[Double](EntityFields.y, map)
-      orientation <- get[Double](EntityFields.orientation, map)
-      radius <- get[Double](LightFields.radius, map)
-      illumintation <- get[Double](LightFields.illuminationRadius, map)
-      intensity <- get[Double](LightFields.intensity, map)
-      attenuation <- get[Double](LightFields.attenuation, map)
+      x <- get[Double](EntityFields.X, map)
+      y <- get[Double](EntityFields.Y, map)
+      orientation <- get[Double](EntityFields.Orientation, map)
+      radius <- get[Double](LightFields.Radius, map)
+      illumination <- get[Double](LightFields.IlluminationRadius, map)
+      intensity <- get[Double](LightFields.Intensity, map)
+      attenuation <- get[Double](LightFields.Attenuation, map)
     yield light
       .at(x, y)
       .withOrientation(Orientation(orientation))
       .withRadius(radius)
-      .withIlluminationRadius(illumintation)
+      .withIlluminationRadius(illumination)
       .withIntensity(intensity)
       .withAttenuation(attenuation)
 end EntityRow

--- a/src/main/scala/io/github/srs/view/components/configuration/EnvironmentSettingsPanel.scala
+++ b/src/main/scala/io/github/srs/view/components/configuration/EnvironmentSettingsPanel.scala
@@ -9,7 +9,6 @@ import io.github.srs.config.yaml.parser.Decoder
 import io.github.srs.model.environment.Environment
 import io.github.srs.model.environment.dsl.CreationDSL.*
 import io.github.srs.utils.SimulationDefaults.Fields.Environment as EnvironmentFields
-import io.github.srs.config.ConfigError
 
 /**
  * EnvironmentSettingsPanel handles the environment-specific configuration settings. It provides a form for configuring
@@ -18,13 +17,11 @@ import io.github.srs.config.ConfigError
  * @param onValidationError
  *   callback triggered when validation fails
  */
-class EnvironmentSettingsPanel(
-    onValidationError: Seq[String] => Unit,
-) extends JPanel(new BorderLayout):
+class EnvironmentSettingsPanel extends JPanel(new BorderLayout):
 
   private val environmentFields = Seq(
-    FieldSpec(EnvironmentFields.width, "Width", io.github.srs.view.components.TextField(5)),
-    FieldSpec(EnvironmentFields.height, "Height", io.github.srs.view.components.TextField(5)),
+    FieldSpec(EnvironmentFields.Width, "Width", io.github.srs.view.components.TextField(5)),
+    FieldSpec(EnvironmentFields.Height, "Height", io.github.srs.view.components.TextField(5)),
   )
 
   private val environmentPanel = new FormPanel("Environment Settings", environmentFields)
@@ -46,8 +43,8 @@ class EnvironmentSettingsPanel(
     val fieldValues = environmentPanel.getValues
 
     for
-      width <- get[Int](EnvironmentFields.width, fieldValues)
-      height <- get[Int](EnvironmentFields.height, fieldValues)
+      width <- get[Int](EnvironmentFields.Width, fieldValues)
+      height <- get[Int](EnvironmentFields.Height, fieldValues)
     yield environment withWidth width withHeight height
 
   /**
@@ -58,27 +55,8 @@ class EnvironmentSettingsPanel(
    */
   def setEnvironment(env: Environment): Unit =
     val environmentMap = Map(
-      EnvironmentFields.width -> env.width.toString,
-      EnvironmentFields.height -> env.height.toString,
+      EnvironmentFields.Width -> env.width.toString,
+      EnvironmentFields.Height -> env.height.toString,
     )
     environmentPanel.setValues(environmentMap)
-
-  /**
-   * Validates the current form values and returns whether they are valid.
-   *
-   * @return
-   *   true if values are valid, false otherwise
-   */
-  def validateFields(): Boolean =
-    getEnvironmentBase match
-      case Left(errors) =>
-        val errorMessages = errors.map:
-          case ConfigError.MissingField(field) => s"Missing field: $field"
-          case ConfigError.ParsingError(message) => s"Parsing error: $message"
-          case ConfigError.InvalidType(field, expected) =>
-            s"Invalid type for $field: expected $expected"
-        onValidationError(errorMessages)
-        false
-      case Right(_) => true
-
 end EnvironmentSettingsPanel

--- a/src/main/scala/io/github/srs/view/components/configuration/SimulationSettingsPanel.scala
+++ b/src/main/scala/io/github/srs/view/components/configuration/SimulationSettingsPanel.scala
@@ -10,22 +10,16 @@ import io.github.srs.model.Simulation
 import io.github.srs.model.Simulation.*
 import io.github.srs.utils.chaining.Pipe.given
 import io.github.srs.utils.SimulationDefaults.Fields.Simulation as SimulationFields
-import io.github.srs.config.ConfigError
 
 /**
  * SimulationSettingsPanel handles the simulation-specific configuration settings. It provides a form for configuring
  * simulation duration and seed.
- *
- * @param onValidationError
- *   callback triggered when validation fails
  */
-class SimulationSettingsPanel(
-    onValidationError: Seq[String] => Unit,
-) extends JPanel(new BorderLayout):
+class SimulationSettingsPanel extends JPanel(new BorderLayout):
 
   private val simulationFields = Seq(
-    FieldSpec(SimulationFields.duration, "Duration", io.github.srs.view.components.TextField(10)),
-    FieldSpec(SimulationFields.seed, "Seed", io.github.srs.view.components.TextField(10)),
+    FieldSpec(SimulationFields.Duration, "Duration", io.github.srs.view.components.TextField()),
+    FieldSpec(SimulationFields.Seed, "Seed", io.github.srs.view.components.TextField()),
   )
 
   private val simulationPanel = new FormPanel("Simulation Settings", simulationFields)
@@ -46,8 +40,8 @@ class SimulationSettingsPanel(
     val fieldValues = simulationPanel.getValues
 
     for
-      duration <- getOptional[Long](SimulationFields.duration, fieldValues)
-      seed <- getOptional[Long](SimulationFields.seed, fieldValues)
+      duration <- getOptional[Long](SimulationFields.Duration, fieldValues)
+      seed <- getOptional[Long](SimulationFields.Seed, fieldValues)
     yield simulation
       |> (s => duration.fold(s)(s.withDuration))
       |> (s => seed.fold(s)(s.withSeed))
@@ -60,27 +54,8 @@ class SimulationSettingsPanel(
    */
   def setSimulation(sim: Simulation): Unit =
     val simulationMap = Map(
-      SimulationFields.duration -> sim.duration.map(_.toString).getOrElse(""),
-      SimulationFields.seed -> sim.seed.map(_.toString).getOrElse(""),
+      SimulationFields.Duration -> sim.duration.map(_.toString).getOrElse(""),
+      SimulationFields.Seed -> sim.seed.map(_.toString).getOrElse(""),
     )
     simulationPanel.setValues(simulationMap)
-
-  /**
-   * Validates the current form values and returns whether they are valid.
-   *
-   * @return
-   *   true if values are valid, false otherwise
-   */
-  def validateFields(): Boolean =
-    getSimulation match
-      case Left(errors) =>
-        val errorMessages = errors.map:
-          case ConfigError.MissingField(field) => s"Missing field: $field"
-          case ConfigError.ParsingError(message) => s"Parsing error: $message"
-          case ConfigError.InvalidType(field, expected) =>
-            s"Invalid type for $field: expected $expected"
-        onValidationError(errorMessages)
-        false
-      case Right(_) => true
-
 end SimulationSettingsPanel

--- a/src/main/scala/io/github/srs/view/components/simulation/ControlsPanel.scala
+++ b/src/main/scala/io/github/srs/view/components/simulation/ControlsPanel.scala
@@ -17,10 +17,10 @@ class ControlsPanel extends JPanel:
   import UI.{ Colors, Dimensions, Icons }
 
   /** Button for starting and stopping the simulation */
-  val startStopButton: JButton = createActionButton("Start", Icons.play)
+  val startStopButton: JButton = createActionButton("Start", Icons.Play)
 
   /** Button for pausing and resuming the simulation */
-  val pauseResumeButton: JButton = createActionButton("Pause", Icons.pause)
+  val pauseResumeButton: JButton = createActionButton("Pause", Icons.Pause)
 
   private val (slowButton, normalButton, fastButton) = createSpeedControls()
 
@@ -47,12 +47,12 @@ class ControlsPanel extends JPanel:
    */
   def updateButtonText(isRunning: Boolean, isPaused: Boolean): Unit =
     startStopButton.setText(
-      if isRunning then s"${Icons.stop} Stop"
-      else s"${Icons.play} Start",
+      if isRunning then s"${Icons.Stop} Stop"
+      else s"${Icons.Play} Start",
     )
     pauseResumeButton.setText(
-      if isPaused then s"${Icons.play} Resume"
-      else s"${Icons.pause} Pause",
+      if isPaused then s"${Icons.Play} Resume"
+      else s"${Icons.Pause} Pause",
     )
 
   /**
@@ -148,7 +148,7 @@ class ControlsPanel extends JPanel:
     button.setFocusPainted(false)
     button.setBorder(new LineBorder(Color.GRAY, 1, true))
     button.setBackground(Color.WHITE)
-    button.setPreferredSize(new Dimension(Dimensions.buttonWidth, Dimensions.buttonHeight))
+    button.setPreferredSize(new Dimension(Dimensions.ButtonWidth, Dimensions.ButtonHeight))
     button.setMargin(new Insets(5, 10, 5, 10))
     button.setOpaque(true)
     button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))

--- a/src/main/scala/io/github/srs/view/components/simulation/SimulationCanvas.scala
+++ b/src/main/scala/io/github/srs/view/components/simulation/SimulationCanvas.scala
@@ -26,8 +26,9 @@ import cats.Id
  * Canvas component responsible for rendering the simulation environment. Supports static layer caching for improved
  * performance.
  *
- * @param alwaysRefresh
- *   If true, the static layer is recreated on every paint
+ * @param insideConfiguration
+ *   If true, the static layer is recreated on every paint and robot sensor lines are not drawn (for configuration
+ *   preview)
  */
 class SimulationCanvas(private val insideConfiguration: Boolean = false) extends JPanel:
 
@@ -49,7 +50,7 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
 
   private val state = new AtomicReference(SimulationViewState())
   private val robotShape = new Ellipse2D.Double()
-  private val gridStroke = new BasicStroke(gridStrokeWidth)
+  private val gridStroke = new BasicStroke(GridStrokeWidth)
 
   /**
    * Updates the canvas with new environment data.
@@ -200,16 +201,16 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
    */
   private def drawLabels(g2: Graphics2D, env: Environment, vp: Viewport): Unit =
     g2.setColor(Color.DARK_GRAY)
-    val bottom = vp.offsetY + vp.height - labelBottomOffset
+    val bottom = vp.offsetY + vp.height - LabelBottomOffset
 
     val step = adaptiveLabelStep(vp.scale)
 
     (0 to env.width by step).foreach { x =>
-      g2.drawString(x.toString, vp.offsetX + (x * vp.scale).toInt + labelXOffset, bottom)
+      g2.drawString(x.toString, vp.offsetX + (x * vp.scale).toInt + LabelXOffset, bottom)
     }
     (0 to env.height by step).foreach { y =>
       val py = vp.offsetY + (y * vp.scale).toInt
-      g2.drawString(y.toString, vp.offsetX + labelXOffset, Math.min(bottom, py + labelYOffset))
+      g2.drawString(y.toString, vp.offsetX + LabelXOffset, Math.min(bottom, py + LabelYOffset))
     }
 
   /**
@@ -221,7 +222,7 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
    *   Step size for label spacing
    */
   private def adaptiveLabelStep(scale: Double): Int =
-    val raw = labelDesiredPx / scale
+    val raw = LabelDesiredPx / scale
     val steps = List(1, 2, 5)
     LazyList
       .iterate(1)(_ * 10)
@@ -296,7 +297,7 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
     g2.fillRect(x, y, width, height)
 
     g2.setColor(Colors.obstacleBorder)
-    g2.setStroke(new BasicStroke(Strokes.obstacleStroke))
+    g2.setStroke(new BasicStroke(Strokes.ObstacleStroke))
     g2.drawRect(x, y, width, height)
 
     g2.setTransform(savedTransform)
@@ -320,7 +321,7 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
 
     val cx = (vp.offsetX + pos.x * vp.scale).toInt
     val cy = (vp.offsetY + pos.y * vp.scale).toInt
-    val size = Math.max(minLightSize, (4 * radius * vp.scale).toInt)
+    val size = Math.max(MinLightSize, (4 * radius * vp.scale).toInt)
     val x = cx - size / 2
     val y = cy - size / 2
 
@@ -334,7 +335,7 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
     g2.setPaint(paint)
     g2.fill(new Ellipse2D.Double(x, y, size, size))
     g2.setColor(Color.ORANGE)
-    g2.setStroke(new BasicStroke(lightStroke))
+    g2.setStroke(new BasicStroke(LightStroke))
     g2.drawOval(x, y, size, size)
 
   end drawLight
@@ -393,7 +394,7 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
    *   True if this robot is currently selected
    */
   private def drawRobotBody(g2: Graphics2D, robot: Robot, radius: Double, vp: Viewport, isSelected: Boolean): Unit =
-    import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.{ normalStroke, selectionStroke }
+    import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.{ NormalStroke, SelectionStroke }
     import io.github.srs.utils.SimulationDefaults.UI.{ Colors, Strokes }
 
     val x = vp.offsetX + (robot.position.x - radius) * vp.scale
@@ -418,11 +419,11 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
     g2.fill(robotShape)
 
     g2.setColor(Colors.robotShadow)
-    g2.setStroke(new BasicStroke(Strokes.robotShadowStroke))
+    g2.setStroke(new BasicStroke(Strokes.RobotShadowStroke))
     g2.draw(robotShape)
 
     g2.setColor(colors._3)
-    val strokeWidth = if isSelected then selectionStroke else normalStroke
+    val strokeWidth = if isSelected then SelectionStroke else NormalStroke
     g2.setStroke(new BasicStroke(strokeWidth))
     g2.draw(robotShape)
 
@@ -446,8 +447,8 @@ class SimulationCanvas(private val insideConfiguration: Boolean = false) extends
     val cx = (vp.offsetX + robot.position.x * vp.scale).toInt
     val cy = (vp.offsetY + robot.position.y * vp.scale).toInt
     val angle = robot.orientation.toRadians
-    val length = radius * arrowLengthFactor * vp.scale
-    val width = math.max(minArrowWidth.toDouble, radius * vp.scale * arrowWidthFactor)
+    val length = radius * ArrowLengthFactor * vp.scale
+    val width = math.max(MinArrowWidth.toDouble, radius * vp.scale * ArrowWidthFactor)
 
     val arrow = createArrowPolygon(cx, cy, angle, length, width)
     g2.setColor(Color.BLACK)

--- a/src/main/scala/io/github/srs/view/components/simulation/TimePanel.scala
+++ b/src/main/scala/io/github/srs/view/components/simulation/TimePanel.scala
@@ -42,7 +42,7 @@ class TimePanel extends JPanel:
     }
 
     List(elapsedValue, remainingValue).foreach { value =>
-      value.setFont(new Font("Monospaced", Font.PLAIN, UI.Fonts.fontSize))
+      value.setFont(new Font("Monospaced", Font.PLAIN, UI.Fonts.FontSize))
       value.setBackground(UI.Colors.backgroundLight)
     }
 

--- a/src/test/scala/io/github/srs/config/YamlConfigManagerTest.scala
+++ b/src/test/scala/io/github/srs/config/YamlConfigManagerTest.scala
@@ -18,7 +18,7 @@ import io.github.srs.utils.SimulationDefaults
 import org.scalatest.OptionValues.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.{ stdLightSensors, stdProximitySensors }
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.{ StdLightSensors, StdProximitySensors }
 import io.github.srs.model.entity.dynamicentity.behavior.BehaviorTypes.Behavior
 import io.github.srs.model.entity.dynamicentity.behavior.Policy
 import io.github.srs.model.environment.Environment
@@ -46,14 +46,14 @@ class YamlConfigManagerTest extends AnyFlatSpec with Matchers:
     val _ = config.environment.entities.exists(e =>
       e.position == Point2D(3, 1) && (e match
         case Robot(_, _, _, _, _, sensors, behavior) =>
-          sensors == stdProximitySensors ++ stdLightSensors &&
+          sensors == StdProximitySensors ++ StdLightSensors &&
           behavior == Policy.AlwaysForward),
     ) should be(true)
 
   "YamlConfigManager" should "save the configuration correctly" in:
-    val obstacleId = SimulationDefaults.StaticEntity.Obstacle.defaultId
-    val lightId = SimulationDefaults.StaticEntity.Light.defaultId
-    val robotId = SimulationDefaults.DynamicEntity.Robot.defaultId
+    val obstacleId = SimulationDefaults.StaticEntity.Obstacle.DefaultId
+    val lightId = SimulationDefaults.StaticEntity.Light.DefaultId
+    val robotId = SimulationDefaults.DynamicEntity.Robot.DefaultId
     val orientation = Orientation(0.0)
     val l =
       light withId lightId at (
@@ -63,7 +63,7 @@ class YamlConfigManagerTest extends AnyFlatSpec with Matchers:
     val o = obstacle withId obstacleId at (2.0, 2.0) withWidth 1.0 withHeight 1.0 withOrientation orientation
     val r = robot withId robotId at (4.0, 4.0) withOrientation orientation withSpeed 1.0 withShape Circle(
       0.5,
-    ) withSpeed 2.0 withSensors (stdProximitySensors ++ stdLightSensors)
+    ) withSpeed 2.0 withSensors (StdProximitySensors ++ StdLightSensors)
 
     val env = environment containing l and o and r
 

--- a/src/test/scala/io/github/srs/config/YamlManagerTest.scala
+++ b/src/test/scala/io/github/srs/config/YamlManagerTest.scala
@@ -17,7 +17,7 @@ import io.github.srs.model.entity.{ Orientation, Point2D }
 import io.github.srs.model.environment.Environment
 import io.github.srs.model.environment.dsl.CreationDSL.*
 import io.github.srs.utils.SimulationDefaults
-import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.{ stdLightSensors, stdProximitySensors }
+import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.{ StdLightSensors, StdProximitySensors }
 import org.scalatest.OptionValues.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -104,7 +104,7 @@ class YamlManagerTest extends AnyFlatSpec with Matchers:
                         val _ = d.right.speed should be(1.0)
                       case _ => fail("Expected a DifferentialWheelMotor actuator")
                   case None => fail("Expected at least one actuator")
-                robot.sensors should be(SimulationDefaults.DynamicEntity.Robot.stdProximitySensors)
+                robot.sensors should be(SimulationDefaults.DynamicEntity.Robot.StdProximitySensors)
               case _ => fail("Expected a Robot entity")
           case _ => fail("Expected a Robot entity")
     end match
@@ -146,9 +146,9 @@ class YamlManagerTest extends AnyFlatSpec with Matchers:
     loadedConfig shouldBe config
 
   it should "convert a SimulationConfig with custom environment to YAML" in:
-    val obstacleId = SimulationDefaults.StaticEntity.Obstacle.defaultId
-    val lightId = SimulationDefaults.StaticEntity.Light.defaultId
-    val robotId = SimulationDefaults.DynamicEntity.Robot.defaultId
+    val obstacleId = SimulationDefaults.StaticEntity.Obstacle.DefaultId
+    val lightId = SimulationDefaults.StaticEntity.Light.DefaultId
+    val robotId = SimulationDefaults.DynamicEntity.Robot.DefaultId
     val orientation = Orientation(0.0)
     val l =
       light withId lightId at (
@@ -158,7 +158,7 @@ class YamlManagerTest extends AnyFlatSpec with Matchers:
     val o = obstacle withId obstacleId at (2.0, 2.0) withWidth 1.0 withHeight 1.0 withOrientation orientation
     val r = robot withId robotId at (4.0, 4.0) withOrientation orientation withSpeed 1.0 withShape Circle(
       0.5,
-    ) withSpeed 2.0 withSensors (stdProximitySensors ++ stdLightSensors)
+    ) withSpeed 2.0 withSensors (StdProximitySensors ++ StdLightSensors)
 
     val env = environment containing l and o and r
 

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/actuator/dsl/DifferentialWheelMotorDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/actuator/dsl/DifferentialWheelMotorDslTest.scala
@@ -13,10 +13,10 @@ class DifferentialWheelMotorDslTest extends AnyFlatSpec with Matchers:
 
   "DifferentialWheelMotor DSL" should "create a differential wheel motor with default wheels" in:
     val motor = differentialWheelMotor
-    val _ = motor.left.speed shouldBe DifferentialWheelMotor.Wheel.defaultSpeed
-    val _ = motor.right.speed shouldBe DifferentialWheelMotor.Wheel.defaultSpeed
-    val _ = motor.left.shape shouldBe DifferentialWheelMotor.Wheel.defaultShape
-    motor.right.shape shouldBe DifferentialWheelMotor.Wheel.defaultShape
+    val _ = motor.left.speed shouldBe DifferentialWheelMotor.Wheel.DefaultSpeed
+    val _ = motor.right.speed shouldBe DifferentialWheelMotor.Wheel.DefaultSpeed
+    val _ = motor.left.shape shouldBe DifferentialWheelMotor.Wheel.DefaultShape
+    motor.right.shape shouldBe DifferentialWheelMotor.Wheel.DefaultShape
 
   it should "set the speed of both wheels using ws" in:
     val speed = 5.0
@@ -28,13 +28,13 @@ class DifferentialWheelMotorDslTest extends AnyFlatSpec with Matchers:
     val speed = 3.0
     val motor = differentialWheelMotor.withLeftSpeed(speed)
     val _ = motor.left.speed shouldBe speed
-    motor.right.speed shouldBe DifferentialWheelMotor.Wheel.defaultSpeed
+    motor.right.speed shouldBe DifferentialWheelMotor.Wheel.DefaultSpeed
 
   it should "set the speed of the right wheel using withRightSpeed" in:
     val speed = 4.0
     val motor = differentialWheelMotor.withRightSpeed(speed)
     val _ = motor.right.speed shouldBe speed
-    motor.left.speed shouldBe DifferentialWheelMotor.Wheel.defaultSpeed
+    motor.left.speed shouldBe DifferentialWheelMotor.Wheel.DefaultSpeed
 
   it should "validate a valid differential wheel motor" in:
     val motor = differentialWheelMotor.ws(1.0)

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/dsl/RobotDslTest.scala
@@ -40,11 +40,11 @@ class RobotDslTest extends AnyFlatSpec with Matchers:
   "Robot DSL" should "create a robot with default properties" in:
     import io.github.srs.utils.SimulationDefaults.DynamicEntity.Robot.*
     val entity = robot
-    val _ = entity.position shouldBe defaultPosition
-    val _ = entity.shape shouldBe defaultShape
-    val _ = entity.orientation shouldBe defaultOrientation
-    val _ = entity.actuators shouldBe defaultActuators
-    entity.sensors shouldBe defaultSensors
+    val _ = entity.position shouldBe DefaultPosition
+    val _ = entity.shape shouldBe DefaultShape
+    val _ = entity.orientation shouldBe DefaultOrientation
+    val _ = entity.actuators shouldBe DefaultActuators
+    entity.sensors shouldBe DefaultSensors
 
   it should "set the position of the robot" in:
     val pos = Point2D(5.0, 5.0)

--- a/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/dynamicentity/sensor/LightSensorTest.scala
@@ -9,7 +9,7 @@ import io.github.srs.model.entity.dynamicentity.{ DynamicEntity, Robot }
 import io.github.srs.model.entity.staticentity.StaticEntity.Light
 import io.github.srs.model.environment.Environment
 import io.github.srs.model.environment.dsl.CreationDSL.*
-import io.github.srs.utils.SimulationDefaults.StaticEntity.Light.{ defaultOrientation, defaultRadius }
+import io.github.srs.utils.SimulationDefaults.StaticEntity.Light.{ DefaultOrientation, DefaultRadius }
 import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.compatible.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
@@ -52,8 +52,8 @@ class LightSensorTest extends AnyFlatSpec with Matchers:
   ): Light =
     Light(
       pos = position,
-      orient = defaultOrientation,
-      radius = defaultRadius,
+      orient = DefaultOrientation,
+      radius = DefaultRadius,
       illuminationRadius = illuminationRadius,
       intensity = intensity,
       attenuation = attenuation,

--- a/src/test/scala/io/github/srs/model/entity/staticentity/dsl/BoundaryDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/staticentity/dsl/BoundaryDslTest.scala
@@ -11,10 +11,10 @@ class BoundaryDslTest extends AnyFlatSpec with Matchers:
   "Boundary DSL" should "create a boundary with default properties" in:
     import io.github.srs.utils.SimulationDefaults.StaticEntity.Boundary.*
     val entity = boundary
-    val _ = entity.pos shouldBe defaultPosition
-    val _ = entity.width shouldBe defaultWidth
-    val _ = entity.height shouldBe defaultHeight
-    entity.orient shouldBe defaultOrientation
+    val _ = entity.pos shouldBe DefaultPosition
+    val _ = entity.width shouldBe DefaultWidth
+    val _ = entity.height shouldBe DefaultHeight
+    entity.orient shouldBe DefaultOrientation
 
   it should "set the position of the boundary" in:
     val pos = (5.0, 5.0)

--- a/src/test/scala/io/github/srs/model/entity/staticentity/dsl/LightDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/staticentity/dsl/LightDslTest.scala
@@ -11,12 +11,12 @@ class LightDslTest extends AnyFlatSpec with Matchers:
   "Light DSL" should "create a light with default properties" in:
     import io.github.srs.utils.SimulationDefaults.StaticEntity.Light.*
     val entity = light
-    val _ = entity.pos shouldBe defaultPosition
-    val _ = entity.orient shouldBe defaultOrientation
-    val _ = entity.radius shouldBe defaultRadius
-    val _ = entity.illuminationRadius shouldBe defaultIlluminationRadius
-    val _ = entity.intensity shouldBe defaultIntensity
-    entity.attenuation shouldBe defaultAttenuation
+    val _ = entity.pos shouldBe DefaultPosition
+    val _ = entity.orient shouldBe DefaultOrientation
+    val _ = entity.radius shouldBe DefaultRadius
+    val _ = entity.illuminationRadius shouldBe DefaultIlluminationRadius
+    val _ = entity.intensity shouldBe DefaultIntensity
+    entity.attenuation shouldBe DefaultAttenuation
 
   it should "set the position of the light" in:
     val pos = (5.0, 5.0)

--- a/src/test/scala/io/github/srs/model/entity/staticentity/dsl/ObstacleDslTest.scala
+++ b/src/test/scala/io/github/srs/model/entity/staticentity/dsl/ObstacleDslTest.scala
@@ -11,10 +11,10 @@ class ObstacleDslTest extends AnyFlatSpec with Matchers:
   "Obstacle DSL" should "create an obstacle with default properties" in:
     import io.github.srs.utils.SimulationDefaults.StaticEntity.Obstacle.*
     val entity = obstacle
-    val _ = entity.pos shouldBe defaultPosition
-    val _ = entity.width shouldBe defaultWidth
-    val _ = entity.height shouldBe defaultHeight
-    entity.orient shouldBe defaultOrientation
+    val _ = entity.pos shouldBe DefaultPosition
+    val _ = entity.width shouldBe DefaultWidth
+    val _ = entity.height shouldBe DefaultHeight
+    entity.orient shouldBe DefaultOrientation
 
   it should "set the position of the obstacle" in:
     val pos = (5.0, 5.0)

--- a/src/test/scala/io/github/srs/model/environment/EnvironmentTest.scala
+++ b/src/test/scala/io/github/srs/model/environment/EnvironmentTest.scala
@@ -58,22 +58,22 @@ class EnvironmentTest extends AnyFlatSpec with Matchers:
       case Left(DomainError.OutOfBounds("height", _, _, _)) => succeed
 
   it should "not be created with width exceeding maximum" in:
-    import io.github.srs.utils.SimulationDefaults.Environment.maxWidth
-    inside(Environment(maxWidth + 1, 10).validate):
+    import io.github.srs.utils.SimulationDefaults.Environment.MaxWidth
+    inside(Environment(MaxWidth + 1, 10).validate):
       case Left(DomainError.OutOfBounds("width", _, _, _)) => succeed
 
   it should "not be created with height exceeding maximum" in:
-    import io.github.srs.utils.SimulationDefaults.Environment.maxHeight
-    inside(Environment(10, maxHeight + 1).validate):
+    import io.github.srs.utils.SimulationDefaults.Environment.MaxHeight
+    inside(Environment(10, MaxHeight + 1).validate):
       case Left(DomainError.OutOfBounds("height", _, _, _)) => succeed
 
   it should "not be created with too many entities" in:
-    import io.github.srs.utils.SimulationDefaults.Environment.maxEntities
+    import io.github.srs.utils.SimulationDefaults.Environment.MaxEntities
     inside(
       Environment(
         10,
         10,
-        (1 to maxEntities + 1)
+        (1 to MaxEntities + 1)
           .map(i => createEntity((i.toDouble, i.toDouble), ShapeType.Circle(1.0), Orientation(0.0)))
           .toSet,
       ).validate,

--- a/src/test/scala/io/github/srs/model/environment/dsl/CreationDSLTest.scala
+++ b/src/test/scala/io/github/srs/model/environment/dsl/CreationDSLTest.scala
@@ -11,8 +11,8 @@ class CreationDSLTest extends AnyFlatSpec with Matchers:
   "CreationDSL" should "create an environment with default values" in:
     import io.github.srs.utils.SimulationDefaults.Environment.*
     val env = environment
-    val _ = env.width shouldBe defaultWidth
-    val _ = env.height shouldBe defaultHeight
+    val _ = env.width shouldBe DefaultWidth
+    val _ = env.height shouldBe DefaultHeight
     env.entities shouldBe empty
 
   it should "allow setting width" in:


### PR DESCRIPTION
This pull request updates the codebase to consistently use capitalized constants throughout the application.
This follows the guidelines as described [here](https://docs.scala-lang.org/style/naming-conventions.html#constants-values-and-variables).