### PR TITLE
refactor: move from ValidEnvironment to Environment

### DIFF
--- a/src/main/scala/io/github/srs/model/environment/Environment.scala
+++ b/src/main/scala/io/github/srs/model/environment/Environment.scala
@@ -65,7 +65,7 @@ final case class Environment(
   private val lightMap: LightMap[IO] = _lightMap.getOrElse(LightMapConfigs.BaseLightMap)
 
   lazy val lightField: LightField =
-    lightMap.computeField(ValidEnvironment.from(this), includeDynamic = true).unsafeRunSync()
+    lightMap.computeField(this, includeDynamic = true).unsafeRunSync()
 
 object ValidEnvironment:
   opaque type ValidEnvironment <: EnvironmentParameters = Environment

--- a/src/main/scala/io/github/srs/model/illumination/IlluminationLogic.scala
+++ b/src/main/scala/io/github/srs/model/illumination/IlluminationLogic.scala
@@ -3,7 +3,7 @@ package io.github.srs.model.illumination
 import scala.collection.immutable.ArraySeq
 
 import io.github.srs.model.entity.staticentity.StaticEntity
-import io.github.srs.model.environment.ValidEnvironment.ValidEnvironment
+import io.github.srs.model.environment.Environment
 import io.github.srs.model.environment.lights
 import io.github.srs.model.illumination.engine.FovEngine
 import io.github.srs.model.illumination.model.*
@@ -50,13 +50,11 @@ object IlluminationLogic:
    * @param includeDynamic
    *   A boolean flag to determine whether dynamic entities should be included in the occlusion map.
    * @param env
-   *   The valid environment containing lights and entities.
+   *   The environment containing lights and entities.
    * @return
    *   A [[LightField]] representing the final intensity value for each cell in the grid.
    */
-  def computeLightField(scale: ScaleFactor)(fov: FovEngine)(includeDynamic: Boolean)(
-      env: ValidEnvironment,
-  ): LightField =
+  def computeLightField(scale: ScaleFactor)(fov: FovEngine)(includeDynamic: Boolean)(env: Environment): LightField =
     given ScaleFactor = scale
 
     val dims = GridDims.from(env)(scale)
@@ -82,7 +80,7 @@ object IlluminationLogic:
    *   A `Grid[Double]` representing the occlusion map.
    */
   private def computeOcclusion(
-      env: ValidEnvironment,
+      env: Environment,
       dims: GridDims,
       includeDynamic: Boolean,
   )(using scale: ScaleFactor): Grid[Double] =

--- a/src/main/scala/io/github/srs/model/illumination/LightMap.scala
+++ b/src/main/scala/io/github/srs/model/illumination/LightMap.scala
@@ -1,7 +1,7 @@
 package io.github.srs.model.illumination
 
 import cats.effect.Sync
-import io.github.srs.model.environment.ValidEnvironment
+import io.github.srs.model.environment.Environment
 import io.github.srs.model.illumination.engine.FovEngine
 import io.github.srs.model.illumination.model.{ LightField, ScaleFactor }
 
@@ -16,13 +16,13 @@ trait LightMap[F[_]]:
    * Compute the [[LightField]] for the given environment.
    *
    * @param env
-   *   The [[ValidEnvironment]] containing entities and lights
+   *   The [[Environment]] containing entities and lights
    * @param includeDynamic
    *   Whether to include dynamic entities in the computation
    * @return
    *   An effectful computation yielding the computed [[LightField]]
    */
-  def computeField(env: ValidEnvironment, includeDynamic: Boolean): F[LightField]
+  def computeField(env: Environment, includeDynamic: Boolean): F[LightField]
 
 /**
  * Companion object for creating instances of [[LightMap]].
@@ -57,7 +57,7 @@ object LightMap:
    */
   private class LightMapImpl[F[_]: Sync](scale: ScaleFactor, fov: FovEngine) extends LightMap[F]:
 
-    def computeField(env: ValidEnvironment, includeDynamic: Boolean): F[LightField] =
+    def computeField(env: Environment, includeDynamic: Boolean): F[LightField] =
       Sync[F].delay:
         IlluminationLogic.computeLightField(scale)(fov)(includeDynamic)(env)
 end LightMap

--- a/src/main/scala/io/github/srs/model/illumination/engine/SquidLibFovEngine.scala
+++ b/src/main/scala/io/github/srs/model/illumination/engine/SquidLibFovEngine.scala
@@ -17,8 +17,8 @@ object SquidLibFovEngine extends FovEngine:
   /**
    * SquidLib-based FoV implementation.
    *
-   * Delegates to `FOV.reuseFOV` using the provided occlusion grid, writing into a reusable buffer, and finally flattens
-   * the matrix in row-major order.
+   * Delegates to [[FOV.reuseFOV]] using the provided occlusion grid, writing into a reusable buffer, and finally
+   * flattens the matrix in row-major order.
    *
    * @param occlusionGrid
    *   A grid of occlusion coefficients in the range [0,1], where:

--- a/src/main/scala/io/github/srs/model/illumination/model/GridDims.scala
+++ b/src/main/scala/io/github/srs/model/illumination/model/GridDims.scala
@@ -1,6 +1,6 @@
 package io.github.srs.model.illumination.model
 
-import io.github.srs.model.environment.ValidEnvironment.ValidEnvironment
+import io.github.srs.model.environment.Environment
 
 /**
  * Grid dimensions for illumination calculations
@@ -46,11 +46,11 @@ object GridDims:
    * Create grid dimensions from environment and scale factor.
    *
    * @param env
-   *   [[ValidEnvironment]] to base dimensions on
+   *   [[Environment]] to base dimensions on
    * @param scale
    *   Scale factor to apply
    */
-  def from(env: ValidEnvironment)(scale: ScaleFactor): GridDims =
+  def from(env: Environment)(scale: ScaleFactor): GridDims =
     GridDims(
       widthCells = math.max(0, env.width * scale),
       heightCells = math.max(0, env.height * scale),

--- a/src/main/scala/io/github/srs/model/illumination/raster/OcclusionRaster.scala
+++ b/src/main/scala/io/github/srs/model/illumination/raster/OcclusionRaster.scala
@@ -5,7 +5,7 @@ import scala.collection.immutable.BitSet
 import io.github.srs.model.entity.*
 import io.github.srs.model.entity.dynamicentity.DynamicEntity
 import io.github.srs.model.entity.staticentity.StaticEntity
-import io.github.srs.model.environment.ValidEnvironment.ValidEnvironment
+import io.github.srs.model.environment.Environment
 import io.github.srs.model.illumination.model.{ Grid, GridDims, ScaleFactor }
 import io.github.srs.utils.SimulationDefaults.Illumination.Occlusion
 
@@ -25,13 +25,13 @@ object OcclusionRaster:
    * Rasterize static occludes obstacles to an occlusion grid.
    *
    * @param env
-   *   The [[ValidEnvironment]] containing all entities
+   *   The [[Environment]] containing all entities
    * @param dims
    *   The dimensions of the target grid
    * @return
    *   A grid where each cell contains the occlusion value (0.0 to 1.0)
    */
-  def rasterizeStatics(env: ValidEnvironment, dims: GridDims)(using ScaleFactor): Grid[Double] =
+  def rasterizeStatics(env: Environment, dims: GridDims)(using ScaleFactor): Grid[Double] =
     val statics = env.entities.iterator.collect:
       case ob: StaticEntity.Obstacle => ob
     rasterizeEntities(statics, dims)
@@ -39,13 +39,13 @@ object OcclusionRaster:
   /**
    * Rasterize all dynamic entities.
    * @param env
-   *   The [[ValidEnvironment]] containing all entities
+   *   The [[Environment]] containing all entities
    * @param dims
    *   The dimensions of the target grid
    * @return
    *   A grid where each cell contains the occlusion value for dynamic entities
    */
-  def rasterizeDynamics(env: ValidEnvironment, dims: GridDims)(using ScaleFactor): Grid[Double] =
+  def rasterizeDynamics(env: Environment, dims: GridDims)(using ScaleFactor): Grid[Double] =
     val dynamics = env.entities.iterator.collect { case d: DynamicEntity => d }
     rasterizeEntities(dynamics, dims)
 


### PR DESCRIPTION
## Summary

* All references to `ValidEnvironment` have been replaced with `Environment` in function parameters, documentation, and imports across all illumination package